### PR TITLE
Upload built Sphinx docs as artifact to allow previewing them on a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
         build-command: "sphinx-build -nW -b html source/ build/html/"
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: ethdebug-format-html
+        path: docs/build/html/


### PR DESCRIPTION
To preview the docs you visit the action and download the zip with HTML docs. You can unpack and view `index.html` in a browser locally.

It would be more convenient if we could upload the directory directly, without packing it. That's what we do in Solidity on CircleCI, and there you can just go directly to `index.html` in the browser. Having a zip is less convenient but probably still good enough.