### PR TITLE
Enable nitpicky-mode and warnings-as-errors in Sphinx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,4 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+        build-command: "sphinx-build -nW -b html source/ build/html/"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,4 +26,6 @@ exclude_patterns = []
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'furo'
-html_static_path = ['_static']
+
+# Enable this when you want to add some static files:
+#html_static_path = ['_static']


### PR DESCRIPTION
More strict checks when building docs. Could end up being annoying, but we run with this enabled by default in Solidity and so far did not run into anything that would make us seriously consider disabling it.