### PR TITLE
Internally called virtual functions necessarily have bodies

### DIFF
--- a/docs/source/format.md
+++ b/docs/source/format.md
@@ -312,8 +312,6 @@ If the callee of the call is known, then the dictionary with sort `"call"` has t
   * `target`: a human readable string name for the function being called
   * `astId`: the AST id of the declaration site of the callee
 
-Note that if the function is being called is `virtual` then the declaration site may not have any corresponding body.
-
 Each element of the arguments array is a dictionary with the following fields:
 * `sort`: `"program"` or `"return_address"`. `"program"` has the same interpretation as in the `type` dictionary above. `"return_address"` is a refinement of the `pc` type indicating this stack slot holds
 the return address of the call being performed.


### PR DESCRIPTION
A small correction to the spec. I can't see how a virtual function called internally would be missing a body. If the bytecode was successfully generated, the call must have been resolved to a valid implementation.

In Solidity such an internal call would be possible only in an abstract contract. Code for such contract can't be generated in isolation. A concrete contract must be derived from it and in that contract the call can be resolved.

This sentence would make sense if "declaration site" refers to the place where the virtual function is first declared (which indeed may not have the body) - but then I wonder why you'd prefer to be pointed to that, rather than to the actual body that is being executed. Actually, the spec should clarify which one is expected here.