### PR TITLE
Add `format.md` to the index

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,4 +7,5 @@
 ./overview.md
 ./known-challenges.md
 ./schema.md
+./format.md
 ```


### PR DESCRIPTION
CI checks in other PRs are failing because the format spec is not included in the index.