### PR TITLE
Specify ethdebug/format/type/base

### DIFF
--- a/schemas/type/base.schema.yaml
+++ b/schemas/type/base.schema.yaml
@@ -1,0 +1,128 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/type/base"
+
+title: ethdebug/format/type/base
+description:
+  Defines the minimally necessary schema for a data type.
+  Types belong to a particular `class` (`"elementary"` or `"complex"`),
+  and are further identified by a particular `kind`.
+type: object
+oneOf:
+  - $ref: "#/$defs/ElementaryType"
+  - $ref: "#/$defs/ComplexType"
+
+$defs:
+  ElementaryType:
+    title: ElementaryType
+    description:
+      Represents an elementary type (one that does not compose other types)
+    type: object
+    properties:
+      class:
+        type: string
+        const: elementary
+      kind:
+        type: string
+      contains:
+        not:
+          description:
+            "**Elementary types must not specify a `contains` field
+            (to make it easier to discriminate elementary vs. complex)**"
+    required:
+      - kind
+    examples:
+      - kind: uint
+        bits: 256
+
+  ComplexType:
+    title: ComplexType
+    description:
+      Represents a complex type, one that composes other types (e.g., arrays,
+      structs, mappings)
+    type: object
+    properties:
+      class:
+        type: string
+        const: complex
+        description: Indicates that this is a complex type
+      kind:
+        type: string
+        description: The specific kind of complex type, e.g., array or struct
+      contains:
+        title: ComplexType.contains
+        oneOf:
+          - $ref: "#/$defs/TypeWrapper"
+          - $ref: "#/$defs/TypeWrapperArray"
+          - $ref: "#/$defs/TypeWrapperObject"
+    required:
+      - kind
+      - contains
+    examples:
+      - kind: array
+        contains:
+          type:
+            kind: uint
+            bits: 256
+      - kind: struct
+        contains:
+          - member: x
+            type:
+              kind: uint
+              bits: 256
+          - member: y
+            type:
+              kind: uint
+              bits: 256
+      - kind: mapping
+        contains:
+          key:
+            type:
+              kind: address
+              payable: true
+          value:
+            type:
+              kind: uint
+              bits: 256
+
+  TypeReference:
+    title: '{ "id": ... }'
+    description: A reference to a known type by ID
+    type: object
+    properties:
+      id:
+        type:
+          - string
+          - number
+    additionalProperties: false
+    required:
+      - id
+
+  TypeWrapper:
+    title: '{ "type": ... }'
+    description:
+      A wrapper around a type. Defines a `"type"` field that may include a full
+      Type representation or a reference to a known Type by ID. Note that this
+      schema permits additional properties on the same object.
+    type: object
+    properties:
+      type:
+        oneOf:
+          - $ref: "schema:ethdebug/format/type/base"
+          - $ref: "#/$defs/TypeReference"
+    required:
+      - type
+
+  TypeWrapperArray:
+    title: '{ "type": ... }[]'
+    description: A list of wrapped types, where the wrapper may add fields
+    type: array
+    items:
+      $ref: "#/$defs/TypeWrapper"
+
+  TypeWrapperObject:
+    title: '{ "key": { "type": ... }, ... }'
+    description:
+      A key-value mapping of wrapped types, where the wrapper may add fields
+    type: object
+    additionalProperties:
+      $ref: "#/$defs/TypeWrapper"

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -1,4 +1,5 @@
 import {themes as prismThemes} from 'prism-react-renderer';
+import path from "path";
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import type { Configuration } from "webpack";
@@ -51,6 +52,25 @@ const config: Config = {
           };
         },
       };
+    },
+
+    async function ignoreBuffer(context, options) {
+      return {
+        name: "ignore-buffer",
+        configureWebpack(config: Configuration) {
+          return {
+            resolve: {
+              alias: {
+                react: path.resolve('./node_modules/react'),
+              },
+              fallback: {
+                buffer: false
+              }
+            }
+          };
+        }
+      }
+
     },
 
     // Used to maintain separate spec/ directory, outside the core docs/
@@ -163,6 +183,9 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
+      additionalLanguages: [
+        "json"
+      ],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/web/package.json
+++ b/web/package.json
@@ -23,13 +23,15 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
-    "docusaurus-json-schema-plugin": "^1.7.0",
+    "docusaurus-json-schema-plugin": "^1.9.0",
     "jsonpointer": "^5.0.1",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "react-markdown": "^9.0.1",
     "yaml": "^2.3.4",
-    "yaml-loader": "^0.8.0"
+    "yaml-loader": "^0.8.0",
+    "yaml-template": "^1.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.0.1",

--- a/web/spec/overview.mdx
+++ b/web/spec/overview.mdx
@@ -11,7 +11,4 @@ section of this website.
 Please see
 [<Icon icon="fa-brands fa-github" />&thinsp;jtoman](https://github.com/jtoman)'s
 [initial prototype](./sketches/prototype) for a natural-language description
-of a format that encompasses some of our group's early ideas. See the
-[Schema](#) section for the work-in-progress formal-language schema
-(using
-[JSON Schema](https://json-schema.org/) draft 2020-12).
+of a format that encompasses some of our group's early ideas.

--- a/web/spec/type/_category_.json
+++ b/web/spec/type/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Schema",
+  "label": "Type schemas",
   "position": 3,
   "link": {
     "type": "generated-index",

--- a/web/spec/type/base.mdx
+++ b/web/spec/type/base.mdx
@@ -1,0 +1,400 @@
+---
+sidebar_position: 3
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+import TOCInline from '@theme/TOCInline';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import yaml from "yaml-template";
+
+# ethdebug/format/type/base
+
+:::warning
+The schema on this page is extended by other, more specific schemas as part of
+the larger **ethdebug/format** specification. These other schemas specify the
+representation of many common kinds of types (e.g. including signed/unsigned
+integers, arrays, structs, mappings, etc.). In order to adhere to this format
+fully, compilers that represent known types **should** do so with the
+appropriate more-specific schema.
+
+Please see the [**ethdebug/format/type**](/spec/type) schema for representing
+these supported types.
+:::
+
+This format defines this base schema (**ethdebug/format/type/base**) for
+representing data types from high-level languages. These types may be
+user-defined or supplied as native data types in a language. This schema
+affords the representation of complex/parametric types, whose definition
+composes other types (e.g., arrays and structs, which contain at least one
+underlying type).
+
+This base schema itself is designed to be extended by other schemas in this
+format. It serves to specify what is _minimally necessary_ for a type to be
+a valid representation (i.e., all type representations **must** adhere to at
+least this base schema).
+
+<TOCInline toc={toc} />
+
+## Key concepts
+
+The **ethdebug/format/type/base** schema includes definitions for a few
+concepts that are worth highlighting here.
+
+### Types are organized by `kind`
+
+:::info[Example: Boolean type]
+```json
+{
+  "kind": "bool"
+}
+```
+:::
+
+An **ethdebug/format/type/base** type representation is a JSON object with a
+`kind` field containing a string value.
+
+This field is intended for use by other **ethdebug/format** schemas, which
+reserve specific string values for the various `kind`s of types that
+this format supports, and for use by implementers of compilers and debuggers
+in situations where coordinating outside this specification is necessary or
+beneficial.
+
+`kind` is a required field for all type representations.
+
+The primary purpose for the `kind` field is to discriminate type objects into
+the appropriate corresponding subschema for a well-understood family of type.
+Although **ethdebug/format/type/base** does not impose any constraints on
+objects based on the `kind` field, it includes this field so as to encourage
+the one-to-one pairing between values for this field and corresponding
+subschemas.
+
+In other words: when extending this schema, ensure there exists exactly one
+corresponding subschema for each defined value of `kind`.
+
+### Elementary vs. complex types
+
+Type representations in this schema fall into one of two `class`es: either
+`"elementary"` or `"complex"`. Type representations express this disinction in
+two ways (the optional `"class"` field, and the absence or existence of a
+`"contains"` field).
+
+- Elementary types do not compose any other types. For example, `uint256` is an
+  elementary type. `string` may be an elementary type for languages that whose
+  semantics treat strings differently than simply an array of characters (like
+  Solidity does).
+
+- Complex types compose at least one other type. For instance, `uint256[]` is
+  an array type that composes an elementary type. Complex types in this schema
+  are polymorphic in how they represent this composition; see
+  [below](#complextypes-contains-field) for information about complex types'
+  `"contains"` field.
+
+### Type wrappers and type references
+
+This schema defines the concept of a type wrapper and the related concept of a
+type reference.
+
+Type wrappers serve to encapsulate a type representation alongside other fields
+in the same object, and to facilitate discriminating which polymorphic form is
+used for a particular complex type.
+
+Type wrappers are any object of the form
+`{ "type": <type>, ...otherProperties }`, where `<type>` is either a complete
+type representation or a reference to another type by ID.
+
+<details>
+<summary>Example type wrapper with complete type representation</summary>
+
+```javascript
+// from a struct type (which defines member types)
+{
+  "member": "beneficiary",
+  "type": {
+    "kind": "address"
+  }
+}
+```
+</details>
+
+<details>
+<summary>Example type wrapper with reference by ID</summary>
+
+```javascript
+{
+  "type": {
+    "id": "<opaque-id>"
+  }
+}
+```
+
+</details>
+
+
+Note that **ethdebug/format/type/base** places no restriction on IDs other than
+that they must be either a number or a string. Other components of this format
+at-large may impose restrictions, however.
+
+#### Type reference schema
+
+A type reference is an object containing the single `"id"` field. This field
+must be a string or a number.
+
+<SchemaViewer
+    schema="schema:ethdebug/format/type/base"
+    pointer="#/$defs/TypeReference" />
+
+#### Type wrapper schema
+
+<SchemaViewer
+    schema="schema:ethdebug/format/type/base"
+    pointer="#/$defs/TypeWrapper"
+    detect={
+    (item) =>
+      typeof item === "object" &&
+        !("$schema" in item) &&
+        item["$ref"] === "#/$defs/Type"}
+    transform={
+      ({ $ref, ...rest }, root) => ({
+        ...rest,
+        type: "object",
+        title: root.$defs.Type.title + " [RECURSIVE]",
+        description: "The root Type schema"
+      })
+    }
+    />
+
+### ComplexType's `"contains"` field
+
+Complex types inherently compose at least one other type and may do so in one
+of three forms:
+- Complex types may compose exactly one other type
+- Complex types may compose an ordered list of other types
+- Complex types may compose an object mapping of specific other types by key
+As described [above](#type-wrappers-and-type-references), complex types compose
+other types. This composition occurs inside the `"contains"` field for all
+complex types.
+
+#### Example complex types to show different forms
+
+<Tabs
+  defaultValue="singleton"
+  values={[
+    { value: "singleton", label: "Single type" },
+    { value: "list", label: "Ordered list of types" },
+    { value: "object", label: "Object mapping of types by key" }
+  ]}>
+  <TabItem value="singleton">
+    This is an example array type, which composes exactly one other type.
+
+    ```json
+    {
+      "kind": "array",
+      "contains": {
+        "type": {
+          "kind": "uint",
+          "bits": 256
+        }
+      }
+    }
+    ```
+  </TabItem>
+  <TabItem value="list">
+    This is an example array type, which composes an ordered list of member
+    types.
+
+    ```json
+    {
+      "kind": "struct",
+      "contains": [{
+        "member": "balance",
+        "type": {
+          "kind": "uint",
+          "bits": 256
+        }
+      }, {
+        "member": "scoreSheet",
+        "type": {
+          "id": "<some opaque ID for some `ScoreSheet` type>"
+        }
+      }]
+    }
+    ```
+
+    In this example, please note how this struct type represents member names
+    with a `"member"` field alongside the `"type"` field, and note how the
+    value of `"type"` can be either a complete representation or a reference
+    object in the form of `{ id }`.
+  </TabItem>
+  <TabItem value="object">
+    This is an example mapping type, which composes an object mapping of types
+    by key.
+    ```json
+    {
+      "kind": "mapping",
+      "contains": {
+        "key": {
+          "type": {
+            "kind": "address"
+          }
+        },
+        "value": {
+          "type": {
+            "kind": "uint",
+            "bits": 256
+          }
+        }
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+## Full base schema
+
+<SchemaViewer
+    schema="schema:ethdebug/format/type/base"
+    detect={
+    (item) =>
+      typeof item === "object" &&
+        !("$schema" in item) &&
+        item["$ref"] === "schema:ethdebug/format/type/base"}
+    transform={
+      ({ $ref, ...rest }, root) => ({
+        ...rest,
+        type: "object",
+        title: root.title + " [RECURSIVE]",
+        description: "The root Type schema"
+      })
+    }
+    />
+## Example schema extensions for particular types
+
+These examples show valid schemas that extend **ethdebug/format/types/base**
+for particular kinds of types.
+
+_**Note**: These are just examples and may not
+correspond to the canonical **ethdebug/format/type** schema._
+
+<Tabs
+  defaultValue="uint"
+  values={[
+    { value: "uint", label: "Example uint type schema" },
+    { value: "array", label: "Example array type schema" },
+    { value: "mapping", label: "Example mapping type schema" },
+  ]}>
+  <TabItem value="uint">
+    <SchemaViewer
+      schema={yaml`
+        $schema: "https://json-schema.org/draft/2020-12/schema"
+        type: object
+        properties:
+          class:
+            type: string
+            const: elementary
+          kind:
+            type: string
+            const: uint
+          bits:
+            type: number
+            multipleOf: 8
+            minimum: 8
+            maximum: 256
+        required:
+          - kind
+          - bits
+        examples:
+          - kind: uint
+            bits: 64
+      `}
+      />
+  </TabItem>
+
+  <TabItem value="array">
+    <SchemaViewer
+      schema={yaml`
+        $schema: "https://json-schema.org/draft/2020-12/schema"
+        type: object
+        properties:
+          class:
+            type: string
+            const: complex
+          kind:
+            type: string
+            const: array
+          contains:
+            type: object
+            properties:
+              type:
+                $ref: "schema:ethdebug/format/type/base#/$defs/Type"
+            required:
+              - type
+        required:
+          - kind
+          - contains
+        examples:
+          - kind: array
+            contains:
+              type:
+                kind: string
+        description:
+          An example schema for array types. See example value for representing
+          an array of strings (\`string[]\`).
+      `}
+      />
+  </TabItem>
+  <TabItem value="mapping">
+    <SchemaViewer
+      schema={yaml`
+        $schema: "https://json-schema.org/draft/2020-12/schema"
+        title: Example mapping type schema
+        type: object
+        properties:
+          class:
+            type: string
+            const: complex
+          kind:
+            type: string
+            const: array
+          contains:
+            type: object
+            properties:
+              key:
+                type: object
+                properties:
+                  type:
+                    $ref: "schema:ethdebug/format/type/base#/$defs/Type"
+                required:
+                  - type
+              value:
+                type: object
+                properties:
+                  type:
+                    $ref: "schema:ethdebug/format/type/base#/$defs/Type"
+                required:
+                  - type
+            required:
+              - key
+              - value
+        required:
+          - kind
+          - contains
+        examples:
+          - kind: mapping
+            contains:
+              key:
+                type:
+                  kind: address
+                  payable: true
+              value:
+                type:
+                  kind: uint
+                  bits: 256
+        description:
+          An example schema for mapping types. See example value for a mapping
+          from an \`address payable\` to a \`uint256\`, adhering to this
+          example schema.
+      `}
+      />
+  </TabItem>
+</Tabs>

--- a/web/spec/type/overview.mdx
+++ b/web/spec/type/overview.mdx
@@ -1,0 +1,98 @@
+---
+sidebar_position: 1
+---
+
+# Overview
+
+:::tip
+**ethdebug/format/type** defines how to write data types as JSON.
+
+Debuggers critically rely on having representations of the data types
+used by a piece of code. This information is used to highlight code display,
+offer links to where user-defined types are defined, and to render runtime
+values correctly.
+
+For a quick introduction to type representations, please see these example
+JSON values:
+
+<details>
+<summary>A valid type representation</summary>
+
+```json
+{
+  "kind": "uint",
+  "bits": 256
+}
+```
+
+</details>
+
+<details>
+<summary>An invalid type representation</summary>
+
+```json
+"uh, some kind of number"
+```
+
+</details>
+
+<!-- TODO add this
+See [additional examples](#example-valid-representations) below
+for a broad sample of valid type representations according to this schema.
+-->
+:::
+
+
+This format defines schemas for representing the data types allowable in a
+supporting high-level language.
+
+JSON values that adhere to this schema may (for example) represent a particular
+`uint` type (like `uint256`), a `struct` type with a particular set of member
+fields, a particular `mapping` type from a certain key type to a certain value
+type, and so on.
+
+This schema is broadly divided into two sections:
+1. A canonical Type schema
+   ([**ethdebug/format/type**](/spec/type)), which includes
+   subschemas for included known types.
+
+   When adhering to this format, this schema is considered **sufficient** for
+   representing any supported type.
+
+2. A base Type schema
+   ([**ethdebug/format/type/base**](/spec/type)), which specifies a
+   minimal definition of any type, known or unknown.
+
+   When adhering to this format, this schema is considered **necessary** for
+   representing any supported type.
+
+In other words:
+
+- Compilers adhering to this format **should** use the canonical
+  **ethdebug/format/type** schema when representing known types
+  (e.g., uints, arrays, structs, etc.).
+
+- Compilers **must** still adhere to the **ethdebug/format/type/base** schema
+  when representing types not known to this format.
+
+:::note
+Any representation adhering to the former also adheres to the latter,
+since **ethdebug/format/type** extends **ethdebug/format/type/base**.
+:::
+
+:::info
+To highlight one purpose behind this separation, consider that this format
+seeks to be complete enough to be useful _and_ flexible enough to afford
+extension.
+
+While **ethdebug/format/type** aims to cover all of the available kinds of
+types available in EVM languages today, languages in the future may offer
+additional kinds of types. **ethdebug/format/type/base** serves to address
+this concern.
+:::
+
+<!-- TODO pull from `examples` in various $defs so as to avoid duplication
+
+## Example valid representations
+
+-->

--- a/web/spec/type/type.mdx
+++ b/web/spec/type/type.mdx
@@ -1,0 +1,21 @@
+---
+sidebar_position: 2
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+import { Collapsible, CreateTypes } from "@theme/JSONSchemaViewer/components";
+import { schemas } from "@site/src/loadSchema";
+
+# ethdebug/format/type [placeholder]
+
+:::note
+
+This schema remains unspecified. Please see the Type schemas
+[Overview](/spec/type/overview) for more information on how these
+schemas will be organized, and/or please review the
+[**ethdebug/format/type/base** schema](/spec/type/base) that is intended
+to serve as base subschema for **ethdebug/format/type**.
+
+We appreciate your interest in these developing efforts.
+
+:::

--- a/web/src/components/SchemaViewer.tsx
+++ b/web/src/components/SchemaViewer.tsx
@@ -1,23 +1,96 @@
 import JSONSchemaViewer from "@theme/JSONSchemaViewer";
+import CodeBlock from "@theme/CodeBlock";
 import { loadSchema } from "@site/src/loadSchema";
+import ReactMarkdown from "react-markdown";
 
 export interface SchemaViewerProps {
-  schema: string;
+  schema: string | object;
   pointer?: string;
+  detect?: (item: object) => boolean;
+  transform?: (item: object, root: object) => object;
+}
+
+
+export const transformObject = (
+  obj: object,
+  predicate: (item: object) => boolean,
+  transform: (item: object, root: object) => object
+): object => {
+  const process = (currentObj: object): object => {
+    if (predicate(currentObj)) {
+      return transform(currentObj, obj);
+    }
+
+    if (typeof currentObj !== 'object' || currentObj === null) {
+      return currentObj;
+    }
+
+    // Using Array.isArray to differentiate between array and object
+    if (Array.isArray(currentObj)) {
+      return currentObj.map(item => process(item));
+    } else {
+      return Object.keys(currentObj).reduce((acc, key) => {
+        acc[key] = process(currentObj[key]);
+        return acc;
+      }, {});
+    }
+  };
+
+  return process(obj);
 }
 
 export default function SchemaViewer({
-  schema,
-  pointer = ""
+  schema: schemaName,
+  pointer = "",
+  detect = () => false,
+  transform = (x) => x
 }: SchemaViewerProps): JSX.Element {
+  const rawSchema = typeof schemaName === "string"
+    ? loadSchema(schemaName)
+    : schemaName;
+  const schema = transformObject(
+    rawSchema,
+    detect,
+    transform
+  );
+
   return (
     <JSONSchemaViewer
-      schema={ loadSchema(schema) }
+      schema={schema}
       resolverOptions={{
-        jsonPointer: pointer
+        jsonPointer: pointer,
+        resolvers: {
+          schema: {
+            resolve: (uri) => {
+              const schema = loadSchema(uri.toString());
+              return schema;
+
+            }
+          }
+        }
       }}
       viewerOptions={{
-        showExamples: true
+        showExamples: true,
+        ValueComponent: ({ value }) => {
+          // deal with simple types first
+          if ([
+            "string",
+            "number",
+            "bigint",
+            "boolean"
+          ].includes(typeof value)) {
+            return <code>{
+              (value as string | number | bigint | boolean).toString()
+            }</code>;
+          }
+
+          // for complex types use a whole CodeBlock
+          return <CodeBlock language="json">{`${
+            JSON.stringify(value, undefined, 2)
+          }`}</CodeBlock>;
+        },
+        DescriptionComponent: ({description}) =>
+          <ReactMarkdown children={description} />
       }} />
   );
 }

--- a/web/src/loadSchema.ts
+++ b/web/src/loadSchema.ts
@@ -1,4 +1,8 @@
+import typeBaseSchemaYaml from "../../schemas/type/base.schema.yaml";
+
+
 export const schemas = [
+  typeBaseSchemaYaml,
 ].map(schema => ({
   [schema.$id]: schema
 })).reduce((a, b) => ({ ...a, ...b }), {});

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3756,10 +3756,10 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-json-schema-plugin@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/docusaurus-json-schema-plugin/-/docusaurus-json-schema-plugin-1.7.0.tgz#e001e1089f13eeca61db9d552cff6e3a520d9576"
-  integrity sha512-Q9m6kIcCzA3CEtzaWBsgXbve8dWHInhO2XRvmJfFM6PYxcabGnmYBgJ13gI3PaIrt8SdBebc9v2ewj2Y0XfpLQ==
+docusaurus-json-schema-plugin@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-json-schema-plugin/-/docusaurus-json-schema-plugin-1.9.0.tgz#c217c88f14b034c182d98dc1344c55907068bb7b"
+  integrity sha512-MZiaNyI/VY8wj3hfAqn6WFCDcmBaLSURlzk+NWT43o+3dw6h0pwJW9GN3NFgqZED2eNSJzJ3c2Y/OBKKKampkA==
   dependencies:
     "@stoplight/json-ref-resolver" "^3.1.5"
     monaco-editor "^0.39.0"
@@ -4737,6 +4737,11 @@ html-tags@^3.3.1:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
   integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
 
+html-url-attributes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.0.tgz#fc4abf0c3fb437e2329c678b80abb3c62cff6f08"
+  integrity sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==
+
 html-void-elements@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
@@ -5206,7 +5211,7 @@ joi@^17.9.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.8.4:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -7150,6 +7155,22 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+react-markdown@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-9.0.1.tgz#c05ddbff67fd3b3f839f8c648e6fb35d022397d1"
+  integrity sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.0.0"
+    hast-util-to-jsx-runtime "^2.0.0"
+    html-url-attributes "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    remark-parse "^11.0.0"
+    remark-rehype "^11.0.0"
+    unified "^11.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
 react-monaco-editor@^0.54.0:
   version "0.54.0"
   resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.54.0.tgz#ec9293249a991b08264be723c1ec0ca3a6d480d8"
@@ -8599,6 +8620,13 @@ yaml-loader@^0.8.0:
     javascript-stringify "^2.0.1"
     loader-utils "^2.0.0"
     yaml "^2.0.0"
+
+yaml-template@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yaml-template/-/yaml-template-1.0.0.tgz#e32e8d4077e67bbfae1e803e0b34e9f2b9298ceb"
+  integrity sha512-TD8Jkay9ScFUBshJAbe4RSWTiRDGBnINXgF5md5O49VZxlzYT3GeIumaA3/hKVLZ3g1p9+BTF0jtoOnyeJ5Dcg==
+  dependencies:
+    js-yaml "^3.8.4"
 
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"


### PR DESCRIPTION
This PR proposes to define the **ethdebug/format/type/base** schema to serve as a minimally-necessary schema for all type representations, to be extended by more-specific subschemas for known kinds of types. This PR also proposes a future **ethdebug/format/type** schema that will extend **ethdebug/format/type/base**.

This takes the organization approach to do the following:
- Define a base schema that doesn't know about uints or strings, etc. It defines the syntactic form of elementary types vs. complex types (types that compose other types). [I imagine we'll add algebraic types to this distinction soon]
- Define a canonical type schema that imposes restrictions on known kinds of types, like to assert that uint types must be specified with a certain number of bits.

For this PR, only the former (base schema) is included, but I've included some stubs for the latter.

Specifically, this PR suggests the following changes:
- Define formal base type schema as JSON Schema (draft 2020/12) in YAML
- Add "Type schemas" section to specification site
  - Include overview page to describe how type schemas are organized
  - Include placeholder page for to-be-written canonical type schema
- Add page to Type schemas section to informally specify ethdebug/format/type/base
  - Introduce purpose of this schema and how it fits more broadly
  - Explain key concepts defined by this schema
  - Represent full base schema via interactive nested React components
  - Provide example (non-canonical) schema extensions for a few types