### PR TITLE
Customize schema component rendering

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^1.2.1",
-    "docusaurus-json-schema-plugin": "^1.9.0",
+    "docusaurus-json-schema-plugin": "^1.10.0",
     "jsonpointer": "^5.0.1",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.0.0",

--- a/web/src/contexts/SchemaContext.tsx
+++ b/web/src/contexts/SchemaContext.tsx
@@ -1,0 +1,19 @@
+import { useContext, createContext } from "react";
+import type { SchemaInfo, SchemaIndex } from "@site/src/schemas";
+
+export interface SchemaContextValue {
+  rootSchemaInfo?: SchemaInfo;
+  schemaIndex: SchemaIndex;
+}
+
+export type PointerSchemaIds = {
+  [jsonPointer: string]: string
+};
+
+export const SchemaContext = createContext<SchemaContextValue>({
+  schemaIndex: {},
+});
+
+export const useSchemaContext = () => useContext(SchemaContext);
+
+export const internalIdKey = Symbol("__$internalId");

--- a/web/src/theme/JSONSchemaViewer/JSONSchemaElements/SchemaConditional/schemaConditional.tsx
+++ b/web/src/theme/JSONSchemaViewer/JSONSchemaElements/SchemaConditional/schemaConditional.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+
+import Translate from "@docusaurus/Translate"
+
+import {
+  IfElseThen,
+  DependentRequired,
+  DependentSchemas,
+  Dependencies,
+} from "@theme-original/JSONSchemaViewer/JSONSchemaElements/SchemaConditional"
+
+import { Collapsible } from "@theme-original/JSONSchemaViewer/components";
+
+
+type Props = {
+  schema: any;
+}
+
+// To handle Schema Conditional (if-then-else , dependentRequired , dependentSchemas , dependencies )
+export default function SchemaConditional(props: Props): JSX.Element {
+  const { schema } = props
+
+  // Checks
+  const isIfThenElse = schema.if !== undefined
+
+  const isDependentRequired =
+    schema.dependentRequired !== undefined
+  const isDependentSchemas =
+    schema.dependentSchemas !== undefined
+  const isDependencies = schema.dependencies !== undefined
+
+  return (
+    <>
+      {/* Handles if-then-else case */}
+      {isIfThenElse && <IfElseThen schema={schema} />}
+      {/* Handles dependentRequired case */}
+      {isDependentRequired && <DependentRequired schema={schema} />}
+      {/* Handles dependentSchemas case */}
+      {isDependentSchemas && <DependentSchemas schema={schema} />}
+      {/* Handles dependencies (deprecated) */}
+      {isDependencies && <Dependencies schema={schema} />}
+    </>
+  )
+}

--- a/web/src/theme/JSONSchemaViewer/JSONSchemaElements/schemaComposition/allOfSchema.tsx
+++ b/web/src/theme/JSONSchemaViewer/JSONSchemaElements/schemaComposition/allOfSchema.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import AllOfSchema from '@theme-original/JSONSchemaViewer/JSONSchemaElements/schemaComposition/allOfSchema';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+import { CreateNodes } from "@theme-original/JSONSchemaViewer/components"
+import {
+  SchemaHierarchyContextProvider,
+  useSchemaHierarchyContext,
+} from "@theme-original/JSONSchemaViewer/contexts"
+import { Collapsible } from "@theme-original/JSONSchemaViewer/components";
+
+export default function allOfSchemaWrapper(props) {
+  const { schema } = props;
+  const { jsonPointer: currentJsonPointer, level: currentLevel } =
+    useSchemaHierarchyContext()
+
+  const discriminator = detectDiscriminator(schema);
+  if (!discriminator) {
+    return (
+      <>
+        <AllOfSchema {...props} />
+      </>
+    );
+  }
+
+  const { propertyName, schemasByConst } = discriminator;
+
+  return (
+    <div>
+      <hr />
+      <span className="badge badge--info">polymorphic discriminator</span>&nbsp;
+      The value of the <strong>{propertyName}</strong> field
+      determines which sub-schema applies:
+
+        <Tabs>{
+          Object.entries(schemasByConst)
+            .map(([value, { schema, index }]) => (
+              <TabItem
+                key={value}
+                label={value}
+                value={value}
+              >
+                <SchemaHierarchyContextProvider
+                  value={{
+                    level: currentLevel + 1,
+                    jsonPointer: `${currentJsonPointer}/allOf/${index}`,
+                  }}
+                >
+                  <CreateNodes schema={schema} />
+                </SchemaHierarchyContextProvider>
+              </TabItem>
+            ))
+        }</Tabs>
+    </div>
+  );
+}
+
+function detectDiscriminator(schema: {
+  allOf: any[]
+}): {
+  propertyName: string;
+  schemasByConst: {
+    [value: string]: {
+      schema: object;
+      index: number;
+    }
+  }
+} | undefined {
+  const { allOf } = schema;
+
+  const allIfThen = allOf.every(
+    (clause: any): clause is { "if": any; then: any } => {
+      const { title, description, "if": if_, then, ...others } = clause;
+
+      return if_ && then && Object.keys(others).length === 0;
+    }
+  )
+
+  if (!allIfThen) {
+    return;
+  }
+
+  const allIfsHaveSinglePropertyWithConst = allOf.every(
+    (ifThen: { "if": any; then: any }): ifThen is {
+      "if": {
+        properties: {
+          [propertyName: string]: {
+            "const": string
+          }
+        }
+      };
+      then: any;
+    } => {
+      const { "if": if_ } = ifThen;
+
+      if (!("properties" in if_)) {
+        return false;
+      }
+
+      const ifProperties = if_.properties;
+
+      if (Object.keys(ifProperties).length !== 1) {
+        return false;
+      }
+
+      const propertyName = Object.keys(ifProperties)[0];
+
+      const { "const": const_ } = ifProperties[propertyName];
+
+      return typeof const_ === "string" && !!const_;
+    }
+  );
+
+  if (!allIfsHaveSinglePropertyWithConst) {
+    return;
+  }
+
+  const propertyName = Object.keys(allOf[0]["if"].properties)[0];
+
+  const schemasByConst = allOf
+    .map(({ "if": if_, then }, index) => {
+      const value = if_.properties[propertyName]["const"];
+
+      return {
+        [value]: {
+          schema: then,
+          index
+        }
+      };
+    })
+    .reduce((a, b) => ({ ...a, ...b }), {});
+
+
+  const isUniquelyDiscriminating =
+    Object.keys(schemasByConst).length === allOf.length;
+
+  if (!isUniquelyDiscriminating) {
+    return;
+  }
+
+  return {
+    propertyName,
+    schemasByConst
+  };
+}
+

--- a/web/src/theme/JSONSchemaViewer/components/CreateNodes.tsx
+++ b/web/src/theme/JSONSchemaViewer/components/CreateNodes.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import CreateTypes from "@theme-original/JSONSchemaViewer/components/CreateTypes";
+import CreateNodes from '@theme-original/JSONSchemaViewer/components/CreateNodes';
+import { useJSVOptionsContext, useSchemaHierarchyContext } from "@theme-original/JSONSchemaViewer/contexts";
+import { useSchemaContext, internalIdKey } from "@site/src/contexts/SchemaContext";
+import Link from "@docusaurus/Link";
+import jsonpointer from "jsonpointer";
+
+export default function CreateNodesWrapper(props) {
+  const { level } = useSchemaHierarchyContext();
+  const { schemaIndex } = useSchemaContext();
+
+  const {
+    schema: {
+      [internalIdKey]: id,
+      ...schema
+    },
+    ...otherProps
+  } = props;
+
+  if (id && id in schemaIndex && level > 0) {
+    const {
+      href,
+      title = `${
+        id.startsWith("schema:")
+          ? id.slice("schema:".length)
+          : id
+      } schema`
+    } = schemaIndex[id];
+
+    return (
+      <>
+        <p>See <Link to={href}>{title}</Link> documentation.</p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <CreateNodes schema={schema} {...otherProps} />
+    </>
+  );
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3756,15 +3756,15 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
-docusaurus-json-schema-plugin@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/docusaurus-json-schema-plugin/-/docusaurus-json-schema-plugin-1.9.0.tgz#c217c88f14b034c182d98dc1344c55907068bb7b"
-  integrity sha512-MZiaNyI/VY8wj3hfAqn6WFCDcmBaLSURlzk+NWT43o+3dw6h0pwJW9GN3NFgqZED2eNSJzJ3c2Y/OBKKKampkA==
+docusaurus-json-schema-plugin@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-json-schema-plugin/-/docusaurus-json-schema-plugin-1.10.0.tgz#33e042b5df9d0f5be9615f4f7e82c88d8c834ad3"
+  integrity sha512-RshMfUsxQQZojCw2GYjJM3q2Ri4nNrruFR1An0HHHybG5/PSKXdUPcDlM3BX5k4MZrPcS2smTRRnFyRV+WHVlA==
   dependencies:
     "@stoplight/json-ref-resolver" "^3.1.5"
-    monaco-editor "^0.39.0"
+    monaco-editor "^0.44.0"
     monaco-editor-webpack-plugin "^7.0.1"
-    react-monaco-editor "^0.54.0"
+    react-monaco-editor "^0.55.0"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -6208,10 +6208,10 @@ monaco-editor-webpack-plugin@^7.0.1:
   dependencies:
     loader-utils "^2.0.2"
 
-monaco-editor@^0.39.0:
-  version "0.39.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.39.0.tgz#3cf8e3718d6aac347d374516a6837d1c13d967d2"
-  integrity sha512-zhbZ2Nx93tLR8aJmL2zI1mhJpsl87HMebNBM6R8z4pLfs8pj604pIVIVwyF1TivcfNtIPpMXL+nb3DsBmE/x6Q==
+monaco-editor@^0.44.0:
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.44.0.tgz#3c0fe3655923bbf7dd647057302070b5095b6c59"
+  integrity sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==
 
 mrmime@^1.0.0:
   version "1.0.1"
@@ -7174,10 +7174,10 @@ react-markdown@^9.0.1:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
-react-monaco-editor@^0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.54.0.tgz#ec9293249a991b08264be723c1ec0ca3a6d480d8"
-  integrity sha512-9JwO69851mfpuhYLHlKbae7omQWJ/2ICE2lbL0VHyNyZR8rCOH7440u+zAtDgiOMpLwmYdY1sEZCdRefywX6GQ==
+react-monaco-editor@^0.55.0:
+  version "0.55.0"
+  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.55.0.tgz#8933e8acc28e177b8b2aaf23593716b8cebf27a8"
+  integrity sha512-GdEP0Q3Rn1dczfKEEyY08Nes5plWwIYU4sWRBQO0+jsQWQsKMHKCC6+hPRwR7G/4aA3V/iU9jSmWPzVJYMVFSQ==
   dependencies:
     prop-types "^15.8.1"
 


### PR DESCRIPTION
- Use new docusaurus-json-schema-plugin version with support for components knowing their own pointer and depth level

- Define "schema index" to allow schemas to have a canonical URL

- When rendering a subschema, check if it has a canonical URL in the index and render a link to that page instead of the full subschema

- Preprocess schemas to add an internal ID field to every object recursively in the schema. Use this ID field when checking against schema index.

- Remove "Conditional subschemas" dropdown that wraps if/then/else constructs

- Define a custom `{ allOf: { if, then } }` detection system to recognize this common pattern for implementing discriminators