### PR TITLE
Render const values in schema dropdown summaries

### DIFF
--- a/web/src/theme/JSONSchemaViewer/utils/generateFriendlyName.tsx
+++ b/web/src/theme/JSONSchemaViewer/utils/generateFriendlyName.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import GenerateFriendlyName from '@theme-original/JSONSchemaViewer/utils/generateFriendlyName';
+
+export default function GenerateFriendlyNameWrapper(props) {
+  const { schema } = props;
+
+  // otherwise just use default rendering
+  return (
+    <>
+      <GenerateFriendlyName {...props} />
+      {
+        "const" in schema
+          ? <span>
+              <> = </><code>{JSON.stringify(schema.const)}</code>
+            </span>
+          : <></>
+      }
+    </>
+  );
+}


### PR DESCRIPTION
<img width="943" alt="Screenshot 2024-01-06 at 22 33 41" src="https://github.com/ethdebug/format/assets/151065/c0ceefa2-a4b9-4a90-9bc8-bd72843cd776">

... because no one wants to have to drill down for such minimal extra signal