### PR TITLE
Run `yarn start` with jest's `--watchAll` flag

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -11,5 +11,5 @@ fi
 concurrently --names=format,web,jest \
   "cd ./packages/format && yarn watch" \
   "cd ./packages/web && yarn start $NO_OPEN_FLAG" \
-  "yarn test --watch"
+  "yarn test --watchAll"
 


### PR DESCRIPTION
Since jest's default --watch does not appear to detect changes to the schemas (or at least it doesn't realize that those changes affect the test results)