### PR TITLE
Switch tests validation output to DETAILED

### DIFF
--- a/packages/tests/src/loadSchemas.ts
+++ b/packages/tests/src/loadSchemas.ts
@@ -40,7 +40,7 @@ const main = () => {
           ? schema.title
           : schemaReference;
 
-      const output = await validate(schemaReference, received, "VERBOSE");
+      const output = await validate(schemaReference, received, "DETAILED");
 
       const pass = output.valid;
 
@@ -65,7 +65,6 @@ const main = () => {
       };
     }
   });
-
 }
 
 main();


### PR DESCRIPTION
(`VERBOSE` mode reported every check, even ones that were valid. Now, when examples fail validation, the tests will only show information about the failed schema checks. Much less noise.)