### PR TITLE
Draft ethdebug/format/pointer schema

### DIFF
--- a/packages/tests/schemas/examples.test.ts
+++ b/packages/tests/schemas/examples.test.ts
@@ -11,6 +11,8 @@ const idsOfSchemasAllowedToOmitExamples = new Set([
   "schema:ethdebug/format/type",
   "schema:ethdebug/format/type/complex",
   "schema:ethdebug/format/type/elementary",
+  "schema:ethdebug/format/pointer/region",
+  "schema:ethdebug/format/pointer/collection",
 ]);
 
 describe("Examples", () => {

--- a/packages/web/spec/overview.mdx
+++ b/packages/web/spec/overview.mdx
@@ -21,6 +21,12 @@ A schema for representing high-level data types such as arrays of integers,
 payable addresses, etc.
 </dd>
 
+<dt>[**ethdebug/format/pointer**](/spec/pointer/overview)</dt>
+<dd>
+A schema for representing dynamic data address ranges in the EVM, particularly
+to indicate where high-level variables are allocated in the machine state.
+</dd>
+
 <dt>(more coming soon)</dt>
 <dd>...</dd>
 

--- a/packages/web/spec/pointer/_category_.json
+++ b/packages/web/spec/pointer/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "ethdebug/format/pointer",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Work-in-progress formal schema for ethdebug format"
+  }
+}

--- a/packages/web/spec/pointer/collection/_category_.json
+++ b/packages/web/spec/pointer/collection/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Collections",
+  "position": 5,
+  "link": {
+    "type": "generated-index",
+    "description": "Work-in-progress formal schema for ethdebug format"
+  }
+}

--- a/packages/web/spec/pointer/collection/collection.mdx
+++ b/packages/web/spec/pointer/collection/collection.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 1
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Collection schema
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/collection" }}
+  />

--- a/packages/web/spec/pointer/collection/conditional.mdx
+++ b/packages/web/spec/pointer/collection/conditional.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 4
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Conditional
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/collection/conditional" }}
+  />

--- a/packages/web/spec/pointer/collection/group.mdx
+++ b/packages/web/spec/pointer/collection/group.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 2
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Group
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/collection/group" }}
+  />

--- a/packages/web/spec/pointer/collection/list.mdx
+++ b/packages/web/spec/pointer/collection/list.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 3
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# List
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/collection/list" }}
+  />

--- a/packages/web/spec/pointer/concepts.mdx
+++ b/packages/web/spec/pointer/concepts.mdx
@@ -1,0 +1,309 @@
+---
+sidebar_position: 2
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Key concepts
+
+## A **pointer** is a region or a collection of other pointers
+
+High-level languages allow programmers to describe and manipulate conceptual
+ideas as succinct, individual building blocks of machine execution.
+Nowadays, thanks to decades of compiler research, resulting low-level machine
+states are often reliably indecipherable, bearing no resemblance at all to
+even basic data abstractions.
+
+The **ethdebug/format/pointer** schema provides a tree-based syntax for
+representing complete (and often minutely detailed) address information for
+finding a particular high-level data object. (For instance: a compiler may need
+to inform a debugger about where to find a particular array in memory.)
+As such, this schema is specified recursively: a pointer is either a single,
+continuous sequence of bytes addresses (a **region**), or it aggregates other
+pointers (a **collection**).
+
+## A **region** is a single continuous range of byte addresses
+
+For simple allocations (like those that fit into a single word), the
+**ethdebug/format/pointer** representation is also quite simple: just a single,
+optionally named, continuous chunk of bytes in the machine state.
+
+<details>
+<summary>
+**Example**: Pointing to the first 32 bytes of memory
+</summary>
+
+```json
+{
+  "name": "memory-start",
+  "location": "memory",
+  "offset": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "length": 32
+}
+```
+
+</details>
+
+This schema defines the concept of a **region** to be the representation
+of the addressing details for a particular block of continuous bytes. Different
+data locations use different, location-specific schemas for regions
+(since, e.g., stack regions are very different than storage regions). The
+**ethdebug/format/pointer/region** schema aggregates these using the
+`"location"` field as a polymorphic discriminator.
+
+## A **collection** aggregates other pointers
+
+Other allocations are not so cleanly represented by a single continuous block
+of bytes anywhere. In these situations, the **ethdebug/format/pointer**
+representation can describe the aggregation of other composed pointers.
+
+<details>
+<summary>
+**Example**: Solidity `struct` in memory
+</summary>
+
+Consider the `struct` definition:
+```solidity
+struct Record {
+    uint256 x;
+    uint256 y;
+}
+```
+
+A minimal way to represent one possible memory allocation for this type is
+to `"group"` together two single-region pointers for each of the two struct
+members.
+
+```json
+{
+  "group": [{
+    "location": "memory",
+    "offset": "0x40",
+    "length": 32
+  }, {
+    "location": "memory",
+    "offset": "0x60",
+    "length": 32
+  }]
+}
+```
+
+</details>
+
+This kind of pointer is defined to be a **collection** of other pointers.
+This schema includes several sub-schemas for different kinds of collections
+(e.g., since the allocation of struct types are very different from the
+allocation of array types, etc.). The **ethdebug/format/pointer/collection**
+schema aggregates these.
+
+
+## Pointers allow describing a value as a complex **expression**
+
+The examples above all use literal values for `"offset"` and `"length"`, but
+these will very often be impossible to predict at compile-time. This format
+provides a JSON-based **expression** syntax for relating the data components
+involved in a complex allocation.
+
+Besides representing byte offsets, word addresses, byte range lengths, etc.
+using just unsigned integer literals, this schema also allows representing
+addressing details via numeric operations, references to named regions,
+explicit EVM lookup, and so on.
+reference to other regions by name, and a few builtin operations.
+
+<details>
+<summary>
+**Example**: Region defined using an arithmetic operation
+</summary>
+
+```json
+{
+  "location": "memory",
+  "offset": {
+    "$sum": [1, 1]
+  },
+  "length": 1
+}
+```
+
+</details>
+
+More expressively, regions whose representations include a
+`"name": "<identifier>"` property allow the use of this `<identifier>` in
+references to this region elsewhere in the pointer representation.
+
+This can be used, for example, to indicate a storage slot whose address is
+known at some point in execution to be the value at the top of the stack.
+
+<details>
+<summary>
+**Example**: Naming a region and reading this region's data from machine state
+</summary>
+
+```json
+{
+  "group": [{
+    "name": "pointer-to-storage-slot",
+    "location": "stack",
+    "slot": 0
+  }, {
+    "name": "storage-slot",
+    "location": "storage",
+    "slot": {
+      "$read": "pointer-to-storage-slot"
+    }
+  }]
+}
+```
+
+</details>
+
+Regions can also be referenced for the purposes of copying fields (to
+avoid duplicating constants, etc.) This is useful, e.g., with structs, whose
+members often are allocated one after the next with no gap. In this example,
+the sub-pointer corresponding to `y` is positioned based on `x`'s offset
+and length.
+
+<details>
+<summary>
+**Example**: Defining regions in terms of other regions
+</summary>
+
+```json
+{
+  "group": [{
+    "name": "record-pointer",
+    "location": "stack",
+    "slot": 0
+  }, {
+    "name": "record-x",
+    "location": "memory",
+    "offset": {
+      "$read": "record-pointer"
+    },
+    "length": 32
+  }, {
+    "name": "record-y",
+    "location": "memory",
+    "offset": {
+      "$sum": [{ ".offset": "record-x" }, { ".length": "record-x" }]
+    },
+    "length": 32
+  }]
+}
+```
+
+</details>
+
+This schema is designed to allow compilers maximal expressiveness in producing
+self-contained representations that are completely knowable at compile-time.
+
+## Collections can be dynamic
+
+For collections whose cardinality or configuration is unpredictable at
+compile-time (e.g., `uint256[]` or `string storage` allocations, respectively),
+and for collections whose static representation would simply be too cumbersome
+(e.g., `bytes32[3200][5600][111]` allocations),
+**ethdebug/format/pointer/collection** provides sub-schemas for describing the
+full set of inter-related data addresses in dynamic terms.
+
+<details>
+<summary>
+**Example**: Representing a dynamically-sized array allocation
+</summary>
+
+The following represents an allocation where the array's item count is stored
+as the leading word-sized sequence of bytes, and each item in the array has
+the same fixed size and appears in memory sequentially following that with no
+gaps.
+
+Notice how `"list": { ... }` expects an object with an expression for the
+value of `"count"`, the name of the scalar variable to represent `"each"`
+item's index in the list, and the underlying pointer for the item itself.
+
+```json
+{
+  "group": [
+    {
+      "name": "array-count",
+      "location": "memory",
+      "offset": "0x40",
+      "length": 32
+    },
+    {
+      "list": {
+        "count": { "$read": "array-count" },
+        "each": "item-index",
+        "is": {
+          "name": "array-item",
+          "location": "memory",
+          "offset": {
+            "$sum": [
+              { ".offset": "array-count" },
+              { ".length": "array-count" },
+              "$product": [
+                "item-index",
+                { ".length": "array-item" }
+              ]
+            ]
+          },
+          "length": 32
+        }
+      }
+    }
+  ]
+}
+```
+
+</details>
+
+## A region is specified in terms of an **addressing scheme**
+
+The EVM models its various data locations in a couple different ways based on
+how bytes are defined to be arranged in each location: e.g., storage is
+arranged in slots, but memory is just one long bytes array.
+
+This pointer schema does not make any attempt to unify these different access
+abstractions, but instead it defines the concept of an **addressing scheme**.
+
+Each location-specific region schema is defined as an extension of the schema
+for a particular addressing scheme.
+
+This format currently defines two such addressing schemes:
+**ethdebug/format/pointer/scheme/slice** and
+**ethdebug/format/pointer/scheme/segment**, for addressing ranges within a
+single continuous byte array and addressing a slot or collection of slots
+in a word-arranged locaton (respectively).
+
+<details>
+<summary>
+**Example**: Slice-based region
+</summary>
+
+This example addresses the 32 bytes starting at location `0x3334` in calldata:
+
+```json
+{
+  "location": "calldata",
+  "offset": "0x3334",
+  "length": "0x20"
+}
+```
+
+</details>
+
+<details>
+<summary>
+**Example**: Segment-based region
+</summary>
+
+This example addresses the first four slots of transient storage (beginning at
+slot 0).
+
+```json
+{
+  "location": "transient",
+  "slot": 0
+}
+```
+
+</details>

--- a/packages/web/spec/pointer/expression.mdx
+++ b/packages/web/spec/pointer/expression.mdx
@@ -1,0 +1,111 @@
+---
+sidebar_position: 6
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Expression syntax
+
+Pointer expressions operate on the domain of bytes representing unsigned
+integers.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  />
+
+## Literal values
+
+An expression can be a literal value.
+
+Literal values **must** be represented either as JSON numbers or as
+`0x`-prefixed hexadecimal strings. Hexadecimal strings always represent a
+literal string of bytes.
+
+For convenience, this schema does not restrict hexadecimal string
+representations to those that specify an even-number of digits (i.e., those
+that specify complete byte pairs); odd numbers of hexadecimal digits are fine.
+
+Hexadecimal string representations **may** omit leading zeroes; values are
+assumed to be left-padded to the bytes width appropriate for the context.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Literal"
+  />
+
+## Scalar variables
+
+An expression can be a string value equal to the identifier for a known
+scalar variable introduced by some pointer representation.
+
+For an example where scalar variables may appear, see the
+[List collection schema](/spec/pointer/collection/list).
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Literal"
+  />
+
+## Arithmetic operations
+
+An expression can be an object of the form `{ <op>: [...] }`, where `<op>`
+denotes an arithmetic operation.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Arithmetic"
+  />
+
+## Lookup region definition
+
+An expression can reference properties defined for a particular region, such as
+another region's `"offset"` or `"length"`. Such expressions resolve to the
+same value as the expression specified for that corresponding property.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Lookup"
+  />
+
+## Reading from the EVM
+
+An expression can be an object of the form `{ "$read": "<region>" }`, where
+`<region>` references a particular region defined in some root pointer.
+
+The value of such an expression is the concatenation of bytes present in the
+running machine state that correspond to the bytes addressed by the referenced
+region.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Read"
+  />
+
+## Keccak256 hashes
+
+An expression can be an object of form `{ "$keccak256": [...] }`, indicating
+that the value of the expression is a Solidity-style, tightly-packed keccak256
+hash of the concatenation of bytes specified by the list.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Keccak256"
+  />
+
+## Region references
+
+Regions can be referenced either by name (which **must** be a defined region),
+or by use of the literal string value `"$this"` (which indicates that the
+referenced region is the region containing the expression itself).
+
+In cases where an expression is used outside the context of a particular
+region definition, the use of `"$this"` is **prohibited**.
+
+Individual properties **may not** be defined with any reference to themselves.
+Properties also **may not** be defined in terms of mutual reference to each
+other. <small>(Don't make this harder than it has to be.)</small>
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Reference"
+  />

--- a/packages/web/spec/pointer/overview.mdx
+++ b/packages/web/spec/pointer/overview.mdx
@@ -1,0 +1,48 @@
+---
+sidebar_position: 1
+---
+
+# Overview
+
+:::tip
+
+**ethdebug/format/pointer** is a JSON schema for pointing to bytes in the EVM.
+
+Debuggers need to know where to find variables when looking at a running
+machine, which means that debuggers must be able to find the related regions
+of the stack, memory, storage, etc. where each of the variables in scope live
+at any point in time.
+
+This gets particularly complicated on the EVM because many common languages
+employ novel techniques for organizing data. (Some of these
+techniques serve to work around machine limitations; others serve to
+take advantage of the unique way the EVM is designed.) For a thorough
+description of how Solidity organizes memory, please see related work
+[Data Representation in Solidity](https://ethdebug.github.io/solidity-data-representation/).
+
+As a consequence of this complexity, this schema seeks to allow compilers the
+expressiveness required for describing these allocation techniques at
+compile-time. To readers continuing on,
+a [warning](https://en.wikipedia.org/wiki/Greenspun%27s_tenth_rule) may apply.
+
+
+:::
+
+This format defines a schema for locating semantically-cohesive bytes ranges
+in a running EVM.
+
+JSON values in this schema describe primarily _where_ data is to be found to
+identify to debuggers reading a trace (or attached to a running EVM) which data
+must be read from which location(s). Values in this schema may address
+a single continuous region of bytes or an aggregation of non-continuous related
+regions.
+
+## Reading this schema
+
+The **ethdebug/format/pointer** schema is a root schema that composes other
+related schemas in the ethdebug/format/pointer/* namespace.
+
+These schemas (like all schemas in this format) are specified as
+[JSON Schema](https://json-schema.org), draft 2020-12.
+
+Please refer to one or more of the following resources in this section:

--- a/packages/web/spec/pointer/pointer.mdx
+++ b/packages/web/spec/pointer/pointer.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 3
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Schema
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer" }}
+  />

--- a/packages/web/spec/pointer/region/_category_.json
+++ b/packages/web/spec/pointer/region/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Regions",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Work-in-progress formal schema for ethdebug format"
+  }
+}

--- a/packages/web/spec/pointer/region/base.mdx
+++ b/packages/web/spec/pointer/region/base.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 4
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Base region schema
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/base" }}
+  />

--- a/packages/web/spec/pointer/region/location/_category_.json
+++ b/packages/web/spec/pointer/region/location/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Location schemas",
+  "position": 3
+}

--- a/packages/web/spec/pointer/region/location/calldata.mdx
+++ b/packages/web/spec/pointer/region/location/calldata.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 4
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# calldata
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/calldata" }}
+  />

--- a/packages/web/spec/pointer/region/location/code.mdx
+++ b/packages/web/spec/pointer/region/location/code.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 7
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `code`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/code" }}
+  />

--- a/packages/web/spec/pointer/region/location/memory.mdx
+++ b/packages/web/spec/pointer/region/location/memory.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 2
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `memory`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/memory" }}
+  />

--- a/packages/web/spec/pointer/region/location/returndata.mdx
+++ b/packages/web/spec/pointer/region/location/returndata.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 5
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# returndata
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/returndata" }}
+  />

--- a/packages/web/spec/pointer/region/location/stack.mdx
+++ b/packages/web/spec/pointer/region/location/stack.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 1
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `stack`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/stack" }}
+  />

--- a/packages/web/spec/pointer/region/location/storage.mdx
+++ b/packages/web/spec/pointer/region/location/storage.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 3
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `storage`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/storage" }}
+  />

--- a/packages/web/spec/pointer/region/location/transient.mdx
+++ b/packages/web/spec/pointer/region/location/transient.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 6
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `transient`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region/transient" }}
+  />

--- a/packages/web/spec/pointer/region/region.mdx
+++ b/packages/web/spec/pointer/region/region.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 1
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Region schema
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/region" }}
+  />

--- a/packages/web/spec/pointer/region/scheme/_category_.json
+++ b/packages/web/spec/pointer/region/scheme/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Addressing schemes",
+  "position": 2
+}

--- a/packages/web/spec/pointer/region/scheme/segment.mdx
+++ b/packages/web/spec/pointer/region/scheme/segment.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 2
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `segment`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/scheme/segment" }}
+  />

--- a/packages/web/spec/pointer/region/scheme/slice.mdx
+++ b/packages/web/spec/pointer/region/scheme/slice.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 1
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# `slice`
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/scheme/slice" }}
+  />

--- a/packages/web/src/schemas.ts
+++ b/packages/web/src/schemas.ts
@@ -61,4 +61,93 @@ export const schemaIndex: SchemaIndex = {
     title: "Parameters schema",
     href: "/spec/type/complex/function#parameters-schema"
   },
+
+  "schema:ethdebug/format/pointer": {
+    href: "/spec/pointer"
+  },
+
+  "schema:ethdebug/format/pointer/region": {
+    href: "/spec/pointer/region"
+  },
+
+  "schema:ethdebug/format/pointer/region/base": {
+    href: "/spec/pointer/region/base"
+  },
+
+  ...(
+    [
+      "stack", "memory", "storage", "calldata", "returndata", "transient",
+      "code"
+    ].map(location => ({
+      [`schema:ethdebug/format/pointer/region/${location}`]: {
+        href: `/spec/pointer/region/location/${location}`
+      }
+    }))
+    .reduce((a, b) => ({ ...a, ...b }), {})
+  ),
+
+  ...(
+    [
+      "slice", "segment"
+    ].map(scheme => ({
+      [`schema:ethdebug/format/pointer/scheme/${scheme}`]: {
+        href: `/spec/pointer/region/scheme/${scheme}`
+      }
+    }))
+    .reduce((a, b) => ({ ...a, ...b }), {})
+  ),
+
+  "schema:ethdebug/format/pointer/collection": {
+    href: "/spec/pointer/collection"
+  },
+
+  ...(
+    [
+      "group", "list", "conditional"
+    ].map(collection => ({
+      [`schema:ethdebug/format/pointer/collection/${collection}`]: {
+        href: `/spec/pointer/collection/${collection}`
+      }
+    }))
+    .reduce((a, b) => ({ ...a, ...b }), {})
+  ),
+
+  "schema:ethdebug/format/pointer/expression": {
+    href: "/spec/pointer/expression"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Literal": {
+    title: "Literal values schema",
+    href: "/spec/pointer/expression#literal-values"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Scalar": {
+    title: "Scalar variable expression schema",
+    href: "/spec/pointer/expression#scalar-variables"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Arithmetic": {
+    title: "Arithmetic operation expression schema",
+    href: "/spec/pointer/expression#arithmetic-operations"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Lookup": {
+    title: "Lookup expression schema",
+    href: "/spec/pointer/expression#lookup-region-definition"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Read": {
+    title: "Read expression schema",
+    href: "/spec/pointer/expression#reading-from-the-evm"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Keccak256": {
+    title: "Keccak256 hash expression schema",
+    href: "/spec/pointer/expression#keccak256-hashes"
+  },
+
+  "schema:ethdebug/format/pointer/expression#/$defs/Reference": {
+    title: "Region reference",
+    href: "/spec/pointer/expression#region-references"
+  },
 };

--- a/schemas/pointer.schema.yaml
+++ b/schemas/pointer.schema.yaml
@@ -1,0 +1,191 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer"
+
+title: ethdebug/format/pointer
+description: |
+  A schema for representing a pointer to a data position or a range of data
+  positions in the EVM.
+
+  An **ethdebug/format/pointer** is either a single region or a structured
+  collection of other pointers.
+
+type: object
+
+oneOf:
+  - $ref: "schema:ethdebug/format/pointer/region"
+  - $ref: "schema:ethdebug/format/pointer/collection"
+
+examples:
+  - # example: a single particular storage slot
+    location: storage
+    slot: 2
+
+  - # example `uint256[] memory` allocation pointer
+    # this pointer composes an ordered list of other pointers
+    group:
+      # declare the first sub-pointer to be the "array-start" region of data
+      # corresponding to the first item in the stack (at time of observation)
+      - name: "array-start"
+        location: stack
+        slot: 0
+
+      # declare the "array-count" region to be at the offset indicated by
+      # the value at "array-start"
+      - name: "array-count"
+        location: memory
+        offset:
+          $read: "array-start"
+        length: $wordsize
+
+      # thirdly, declare a sub-pointer that is a dynamic list whose size is
+      # indicated by the value at "array-count", where each "item-index"
+      # corresponds to a discrete "array-item" region
+      - list:
+          count:
+            $read: "array-count"
+          each: "item-index"
+          is:
+            name: "array-item"
+            location: "memory"
+            offset:
+              # array items are positioned so that the item with index 0
+              # immediately follows "array-count", and each subsequent item
+              # immediately follows the previous.
+              $sum:
+                - .offset: "array-count"
+                - .length: "array-count"
+                - $product:
+                    - "item-index"
+                    - .length: "array-item"
+            length: $wordsize
+
+  - # example `struct Record { uint128 x; uint128 y }` in memory
+    group:
+      - name: "struct-start"
+        location: stack
+        slot: 0
+
+      - name: "struct-member-0"
+        location: memory
+        # the first struct member begins at the offset indicated by the value
+        # at "struct-start"
+        offset:
+          $read: "struct-start"
+        length: $wordsize
+
+      - name: "struct-member-1"
+        location: memory
+        # the second struct member immediately follows the first
+        offset:
+          $sum:
+            - .offset: "struct-member-0"
+            - .length: "struct-member-0"
+        length: $wordsize
+
+  - # example `(struct Record { uint256 x; uint256 y; })[] memory`
+    group:
+      # declare the first sub-pointer to be the "array-start" region of data
+      # corresponding to the first item in the stack (at time of observation)
+      - name: "array-start"
+        location: stack
+        slot: 0
+
+      # declares the "array-count" region in memory at the offset indicated
+      # by "array-start" and of length equal to word size
+      - name: "array-count"
+        location: memory
+        offset:
+          $read: "array-start"
+        length: $wordsize
+
+      # declare this to include a list of pointers of size indicated by the
+      # value at "array-count", where each "item-index" corresponds to a
+      # group of pointers
+      - list:
+          count:
+            $read: "array-count"
+          each: "item-index"
+          is:
+            group:
+              # each element in the list includes a "struct-pointer" region
+              # in memory (laid out sequentially in a block as the raw
+              # array data)
+              - name: "struct-pointer"
+                location: memory
+                offset:
+                  $sum:
+                    - .offset: "array-count"
+                    - .length: "array-count"
+                    - $product:
+                      - "item-index"
+                      - .length: "struct-pointer"
+                length: $wordsize
+
+              # following that pointer leads to the region corresponding to
+              # the first member of the struct
+              - name: "struct-member-0"
+                location: memory
+                offset:
+                  $read: "struct-pointer"
+                length: $wordsize
+
+              # the second struct member immediately follows the first
+              - name: "struct-member-1"
+                location: memory
+                offset:
+                  $sum:
+                    - .offset: "struct-member-0"
+                    - .length: "struct-member-0"
+                length: $wordsize
+
+  - # example `string storage` allocation
+    group:
+      # for short strings, the length is stored as 2n in the last byte of slot
+      - name: "length-flag"
+        location: storage
+        slot: 0
+        offset:
+          $difference:
+            - $wordsize
+            - 1
+        length: 1
+
+      # long strings may use full word to describe length as 2n+1
+      - name: "long-length-data"
+        location: storage
+        slot:
+          .slot: "length-flag"
+        offset: 0
+        length: $wordsize
+
+      # define the region representing the string data itself conditionally
+      # based on odd or even length data
+      - if:
+          $remainder:
+            - $read: "length-flag"
+            - 2
+        then:
+          name: "string"
+          location: storage
+          slot:
+            $keccak256:
+              - .slot: "length-flag"
+          offset: 0
+          length:
+            # length n is encoded as 2n+1
+            $quotient:
+              - $difference:
+                  - $read: "long-length-data"
+                  - 1
+              - 2
+        else:
+          name: "string"
+          location: storage
+          slot:
+            .slot: "length-flag"
+          offset: 0
+          length:
+            # length n is encoded as 2n
+            $quotient:
+              - $read: "length-flag"
+              - 2

--- a/schemas/pointer/collection.schema.yaml
+++ b/schemas/pointer/collection.schema.yaml
@@ -1,0 +1,33 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/collection"
+
+title: ethdebug/format/pointer/collection
+description: |
+  A representation of a collection of pointers to data in the EVM
+type: object
+
+allOf:
+  - oneOf:
+      - required:
+          - group
+      - required:
+          - list
+      - required:
+          - if
+  - if:
+      required:
+        - group
+    then:
+      $ref: "schema:ethdebug/format/pointer/collection/group"
+
+  - if:
+      required:
+        - list
+    then:
+      $ref: "schema:ethdebug/format/pointer/collection/list"
+
+  - if:
+      required:
+        - if
+    then:
+      $ref: "schema:ethdebug/format/pointer/collection/conditional"

--- a/schemas/pointer/collection/conditional.schema.yaml
+++ b/schemas/pointer/collection/conditional.schema.yaml
@@ -1,0 +1,33 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/collection/conditional"
+
+title: ethdebug/format/pointer/collection/conditional
+description: |
+  A pointer defined conditionally based on the non-zero-ness of some expression
+
+type: object
+
+properties:
+  if:
+    $ref: "schema:ethdebug/format/pointer/expression"
+  then:
+    $ref: "schema:ethdebug/format/pointer"
+  else:
+    $ref: "schema:ethdebug/format/pointer"
+
+required:
+  - if
+  - then
+
+additionalProperties: false
+
+examples:
+  - if: 0
+    then:
+      location: memory
+      offset: 0
+      length: 1
+    else:
+      location: memory
+      offset: 1
+      length: 1

--- a/schemas/pointer/collection/group.schema.yaml
+++ b/schemas/pointer/collection/group.schema.yaml
@@ -1,0 +1,26 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/collection/group"
+
+title: ethdebug/format/pointer/collection/group
+description: |
+  A composite collection of pointers
+type: object
+properties:
+  group:
+    type: array
+    items:
+      $ref: "schema:ethdebug/format/pointer"
+    minItems: 1
+required:
+  - group
+additionalProperties: false
+
+examples:
+  - group:
+      - name: "data-pointer"
+        location: stack
+        slot: 0
+      - location: memory
+        offset:
+          $read: "data-pointer"
+        length: 32

--- a/schemas/pointer/collection/list.schema.yaml
+++ b/schemas/pointer/collection/list.schema.yaml
@@ -1,0 +1,44 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/collection/list"
+
+title: ethdebug/format/pointer/collection/list
+description: |
+  An ordered list of pointers, indexed starting at zero.
+type: object
+
+properties:
+  list:
+    type: object
+    properties:
+      count:
+        description: |
+          The size of the list that this collection represents.
+        $ref: "schema:ethdebug/format/pointer/expression"
+      each:
+        description: |
+          An identifier name whose value as an expression resolves to the index
+          in the list
+        $ref: "schema:ethdebug/format/pointer/identifier"
+      is:
+        description: |
+          The dynamically-generated pointer repeated as a list
+        $ref: "schema:ethdebug/format/pointer"
+    required:
+      - count
+      - each
+      - is
+
+required:
+  - list
+
+additionalProperties: false
+
+examples:
+  - list:
+      count: 5
+      each: "index"
+      is:
+        location: memory
+        offset:
+          $read: "index"
+        length: 1

--- a/schemas/pointer/expression.schema.yaml
+++ b/schemas/pointer/expression.schema.yaml
@@ -1,0 +1,203 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/expression"
+
+title: ethdebug/format/pointer/expression
+description: |
+  A schema for describing expressions that evaluate to values.
+
+oneOf:
+  - $ref: "#/$defs/Literal"
+  - $ref: "#/$defs/Variable"
+  - $ref: "#/$defs/Constant"
+  - $ref: "#/$defs/Arithmetic"
+  - $ref: "#/$defs/Lookup"
+  - $ref: "#/$defs/Read"
+  - $ref: "#/$defs/Keccak256"
+
+$defs:
+  Literal:
+    title: Literal value
+    description: |
+      An unsigned number or a `0x`-prefixed string of hexadecimal digits
+
+    oneOf:
+      - type: integer
+        description: A non-negative integer literal
+        min: 0
+
+      - type: string
+        description: |
+          A `0x`-prefixed hexadecimal string representing literal bytes
+        pattern: "^0x[0-9a-fA-F]{1,}$"
+
+    examples:
+      - 5
+      - "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+  Constant:
+    title: Constant value
+    type: string
+    enum:
+      - $wordsize
+
+  Variable:
+    title: Variable identifier
+    description: |
+      A string that matches an identifier used in an earlier declaration of
+      a scalar variable. This expression evaluates to the value of that
+      variable.
+    $ref: "schema:ethdebug/format/pointer/identifier"
+
+  Arithmetic:
+    title: Arithmetic operation
+    type: object
+    properties:
+      "$sum":
+        description: |
+          A list of expressions to be added together.
+        $ref: "#/$defs/Operands"
+      "$difference":
+        description: |
+          A tuple of two expressions where the second is to be subtracted from
+          the first.
+
+          (i.e., `{ "$difference": [a, b] }` equals `a` minus `b`.)
+        $ref: "#/$defs/Operands"
+        minItems: 2
+        maxItems: 2
+      "$product":
+        description: |
+          A list of expressions to be multipled.
+        $ref: "#/$defs/Operands"
+      "$quotient":
+        description: |
+          A tuple of two expressions where the first corresponds to the
+          dividend and the second corresponds to the divisor, for the purposes
+          of doing integer division.
+
+          (i.e., `{ "$quotient": [a, b] }` equals `a` divided by `b`.)
+        $ref: "#/$defs/Operands"
+        minItems: 2
+        maxItems: 2
+      "$remainder":
+        description: |
+          A tuple of two expressions where the first corresponds to the
+          dividend and the second corresponds to the divisor, for the purposes
+          of computing the modular-arithmetic remainder.
+
+          (i.e., `{ "$remainder": [a, b] }` equals `a` mod `b`.)
+        $ref: "#/$defs/Operands"
+        minItems: 2
+        maxItems: 2
+    additionalProperties: false
+    minProperties: 1
+    maxProperties: 1
+    examples:
+      - "$sum": [5, 3, 4]
+      - "$difference": [5, 3]
+      - "$product": [5, 3, 0]
+      - "$quotient": [5, 3]
+      - "$remainder":
+          - "$product":
+            - 2
+            - 2
+            - 2
+            - 2
+          - 3
+
+  Operands:
+    type: array
+    items:
+      $ref: "schema:ethdebug/format/pointer/expression"
+
+  Lookup:
+    title: Lookup region definition
+    description: |
+      An object of the form `{ ".<property-name>": "<region>" }`, to
+      denote that this expression is equivalent to the defined value for
+      the property named `<property-name>` inside the region referenced as
+      `<region>`.
+
+      `<property-name>` **must** be a valid and present property on the
+      corresponding region, or it **must** correspond to an optional property
+      whose schema specifies a default value for that property.
+    type: object
+    patternProperties:
+      "^\\.(offset|length|slot)$":
+        $ref: "#/$defs/Reference"
+    additionalProperties: false
+    minProperties: 1
+    maxProperties: 1
+
+    examples:
+      - .offset: "array-count"
+      - .length: "array-item"
+      - .offset: $this
+
+
+  Read:
+    title: Read region bytes
+    description: |
+      An object of the form `{ "$read": "<region>" }`. The value of this
+      expression equals the raw bytes present in the running machine state
+      in the referenced region.
+    type: object
+    properties:
+      $read:
+        $ref: "#/$defs/Reference"
+    required:
+      - $read
+    additionalProperties: false
+    examples:
+      - $read: "struct-start"
+
+  Reference:
+    title: Region reference
+    description: |
+      A string value that **must** either be the `"name"` of at least one
+      region declared with `{ "name": "<region>" }` previously in some root
+      pointer representation, or it **must** be the literal value `"$this"`,
+      which indicates a reference to the region containing this expression.
+
+      If more than one region is defined with the same name, resolution is
+      defined as firstly resolving to the latest earlier sibling that declares
+      the matching name, then secondly resolving to the parent if it matches,
+      then to parent's earlier siblings, and so on.
+    type: string
+
+    oneOf:
+      - $ref: "schema:ethdebug/format/pointer/identifier"
+      - const: "$this"
+        description: |
+          Indicates a reference to the region containing this expression.
+
+  Keccak256:
+    title: Keccak256 hash
+    description: |
+      An object of the form `{ "keccak256": [...values] }`, indicating that this
+      expression evaluates to the Solidity-style keccak256 hash of the
+      tightly-packed bytes encoded by `values`.
+    type: object
+    properties:
+      $keccak256:
+        title: Array of hashed values
+        type: array
+        items:
+          $ref: "schema:ethdebug/format/pointer/expression"
+    additionalProperties: false
+    required:
+      - $keccak256
+    examples:
+      - $keccak256:
+          - 0
+          - "0x00"
+
+examples:
+  - 0
+  - $sum:
+      - .offset: "array-start"
+      - .length: "array-start"
+      - 1
+  - $keccak256:
+      - 5
+      - .offset: "array-start"

--- a/schemas/pointer/identifier.schema.yaml
+++ b/schemas/pointer/identifier.schema.yaml
@@ -1,0 +1,14 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/identifier"
+
+title: ethdebug/format/pointer/identifier
+description: |
+  An identifier for use within the context of a root pointer
+type: string
+pattern: "^[a-zA-Z_\\-]+[a-zA-Z0-9$_\\-]*$"
+
+examples:
+  - a
+  - a0
+  - -$
+  - __init__

--- a/schemas/pointer/region.schema.yaml
+++ b/schemas/pointer/region.schema.yaml
@@ -1,0 +1,83 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region"
+
+title: ethdebug/format/pointer/region
+description: |
+  A representation of a region of data in the EVM
+type: object
+
+properties:
+  location:
+    $ref: "#/$defs/Location"
+
+
+allOf:
+  - if:
+      properties:
+        location:
+          const: stack
+
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/stack"
+
+  - if:
+      properties:
+        location:
+          const: memory
+
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/memory"
+
+  - if:
+      properties:
+        location:
+          const: storage
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/storage"
+
+  - if:
+      properties:
+        location:
+          const: calldata
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/calldata"
+
+  - if:
+      properties:
+        location:
+          const: returndata
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/returndata"
+
+  - if:
+      properties:
+        location:
+          const: transient
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/transient"
+
+  - if:
+      properties:
+        location:
+          const: code
+    then:
+      $ref: "schema:ethdebug/format/pointer/region/code"
+
+$defs:
+  Location:
+    type: string
+    enum:
+      - stack
+      - memory
+      - storage
+      - calldata
+      - returndata
+      - transient
+      - code
+
+unevaluatedProperties: false
+
+examples:
+  - location: storage
+    slot: "0x0000000000000000000000000000000000000000000000000000000000000000"
+

--- a/schemas/pointer/region/base.schema.yaml
+++ b/schemas/pointer/region/base.schema.yaml
@@ -1,0 +1,21 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/base"
+
+title: ethdebug/format/pointer/region/base
+description: |
+  Common schema for all region schemas, regardless of `"location": ...`.
+
+type: object
+properties:
+  name:
+    $ref: "schema:ethdebug/format/pointer/identifier"
+
+  location:
+    type: string
+
+required:
+  - location
+
+examples:
+  - name: "array-item"
+    location: memory

--- a/schemas/pointer/region/calldata.schema.yaml
+++ b/schemas/pointer/region/calldata.schema.yaml
@@ -1,0 +1,28 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/calldata"
+
+title: ethdebug/format/pointer/region/calldata
+description: |
+  A schema for representing a region of data in message calldata.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the slice addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "calldata" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: calldata
+
+    required:
+      - location
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/slice"
+
+unevaluatedProperties: false
+
+examples:
+  - location: calldata
+    offset: "0x04"
+    length: 32

--- a/schemas/pointer/region/code.schema.yaml
+++ b/schemas/pointer/region/code.schema.yaml
@@ -1,0 +1,28 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/code"
+
+title: ethdebug/format/pointer/region/code
+description: |
+  A schema for representing a region of data in EVM bytecode.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the slice addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "code" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: code
+
+    required:
+      - location
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/slice"
+
+unevaluatedProperties: false
+
+examples:
+  - location: code
+    offset: "0x04"
+    length: 32

--- a/schemas/pointer/region/memory.schema.yaml
+++ b/schemas/pointer/region/memory.schema.yaml
@@ -1,0 +1,29 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/memory"
+
+title: ethdebug/format/pointer/region/memory
+description: |
+  A schema for representing a region of data in EVM memory. Pointer regions
+  within memory represent a single/atomic sequence of byte locations.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the slice addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "memory" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: memory
+
+    required:
+      - location
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/slice"
+
+unevaluatedProperties: false
+
+examples:
+  - location: memory
+    offset: "0x04"
+    length: 32

--- a/schemas/pointer/region/returndata.schema.yaml
+++ b/schemas/pointer/region/returndata.schema.yaml
@@ -1,0 +1,28 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/returndata"
+
+title: ethdebug/format/pointer/region/returndata
+description: |
+  A schema for representing a region of data in message returndata.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the slice addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "returndata" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: returndata
+
+    required:
+      - location
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/slice"
+
+unevaluatedProperties: false
+
+examples:
+  - location: returndata
+    offset: "0x04"
+    length: 32

--- a/schemas/pointer/region/stack.schema.yaml
+++ b/schemas/pointer/region/stack.schema.yaml
@@ -1,0 +1,38 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/stack"
+
+title: ethdebug/format/pointer/region/stack
+description: |
+  A schema for representing a region of data in the EVM.
+
+  Describes stack slots as number of positions from the top (at time of
+  observation). Debuggers reading this information **should** immediately
+  convert these positions to absolute positions from the bottom.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the segment addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "stack" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: stack
+
+    required:
+      - location
+
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/segment"
+
+unevaluatedProperties: false
+
+examples:
+  - location: stack
+    slot: 0
+  - location: stack
+    slot: 1
+    length:
+      $product:
+        - $wordsize
+        - 2

--- a/schemas/pointer/region/storage.schema.yaml
+++ b/schemas/pointer/region/storage.schema.yaml
@@ -1,0 +1,44 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/storage"
+
+title: ethdebug/format/pointer/region/storage
+description: |
+  A schema for representing a region of data in EVM storage.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the segment addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "storage" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: storage
+
+    required:
+      - location
+
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/segment"
+
+unevaluatedProperties: false
+
+examples:
+  - location: storage
+    slot: "0x03"
+  - location: storage
+    slot: "0x06"
+    length:
+      $product:
+        - $wordsize
+        - 2
+  - location: storage
+    slot: "0x08"
+    offset:
+      $quotient:
+        - $wordsize
+        - 2
+    length:
+      $quotient:
+        - $wordsize
+        - 2

--- a/schemas/pointer/region/transient.schema.yaml
+++ b/schemas/pointer/region/transient.schema.yaml
@@ -1,0 +1,44 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/region/transient"
+
+title: ethdebug/format/pointer/region/transient
+description: |
+  A schema for representing a region of data in EVM transient storage.
+
+  This schema is constructed by extending the base region schema
+  and the schema for the segment addressing scheme.
+type: object
+
+allOf:
+  - title: '{ "location": "transient" }' # note: whitespace chars are \255 (nbsp)
+    properties:
+      location:
+        const: transient
+
+    required:
+      - location
+
+  - $ref: "schema:ethdebug/format/pointer/region/base"
+  - $ref: "schema:ethdebug/format/pointer/scheme/segment"
+
+unevaluatedProperties: false
+
+examples:
+  - location: transient
+    slot: "0x03"
+  - location: transient
+    slot: "0x06"
+    length:
+      $product:
+        - $wordsize
+        - 2
+  - location: transient
+    slot: "0x08"
+    offset:
+      $quotient:
+        - $wordsize
+        - 2
+    length:
+      $quotient:
+        - $wordsize
+        - 2

--- a/schemas/pointer/scheme/segment.schema.yaml
+++ b/schemas/pointer/scheme/segment.schema.yaml
@@ -1,0 +1,62 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/scheme/segment"
+
+title: ethdebug/format/pointer/scheme/segment
+description: |
+  An addressing scheme for pointing to a range of bytes in a data location
+  arranged as individually-addressable word-sized slots.
+
+  **Note** that this addressing scheme permits addressing byte ranges that
+  extend beyond the last byte of a particular slot, or even covering the range
+  of multiple slots.
+
+  In such cases, this schema defines the range as the concatenation of bytes
+  across slots such that the address of the first byte after the end of slot
+  `p` (i.e., `{ "offset": "$wordsize" }`) is interpreted as the first byte of
+  slot `p + 1`.
+
+type: object
+
+properties:
+  slot:
+    $ref: "schema:ethdebug/format/pointer/expression"
+  offset:
+    description: |
+      The starting byte index within the slot.
+
+      This field is **optional**. If unspecified, it has the default value of
+      `0`, indicating that the segment begins at the start of the specified
+      slot.
+
+      This field's expression must resolve to a value _n_ such that
+      0&nbsp;≤&nbsp;_n_&nbsp;\<&nbsp;`$wordsize` (i.e., the offset **must**
+      begin inside the slot).
+    $ref: "schema:ethdebug/format/pointer/expression"
+    default: 0
+  length:
+    description: |
+      The length of the bytes range this segment represents.
+
+      This field is **optional**. If unspecified, its default value indicates
+      that the segment ends at the end of the slot.
+
+      If this field has value larger than the default value, i.e., if the
+      segment extends beyond the last byte in the slot, then this segment is
+      defined to be the concatenation of the sequentially-addressed slot(s)
+      following following the slot specified.
+    $ref: "schema:ethdebug/format/pointer/expression"
+    default:
+      $difference:
+        - $wordsize
+        - .offset: $this
+
+required:
+  - slot
+
+examples:
+  - slot: 0
+  - slot: 1
+    length:
+      $product:
+        - $wordsize
+        - 3

--- a/schemas/pointer/scheme/slice.schema.yaml
+++ b/schemas/pointer/scheme/slice.schema.yaml
@@ -1,0 +1,29 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/pointer/scheme/slice"
+
+title: ethdebug/format/pointer/scheme/slice
+description: |
+  An addressing scheme for pointing to a range of sequential bytes inside
+  a data location whose structure is that of a regular bytes array
+  (i.e., where bytes are indexed by byte offset, with no concept of word).
+
+type: object
+
+properties:
+  offset:
+    description: |
+      The index of the byte (starting from zero) in the data location where
+      the slice begins.
+    $ref: "schema:ethdebug/format/pointer/expression"
+  length:
+    description: |
+      The length of the slice in number of bytes.
+    $ref: "schema:ethdebug/format/pointer/expression"
+
+required:
+  - offset
+  - length
+
+examples:
+  - offset: 0
+    length: 32


### PR DESCRIPTION
- Define a pointer to be a region or collection of pointers

- Define a region to be an optionally-named, continuous sequence of bytes somewhere
- Define slice and segment addressing schemes for memory-like addresses and storage-like addresses, respectively
- Define different regions for different data locations using the appropriate addressing scheme

- Allow a static group of pointers as a collection
- Allow a dynamic list of pointers as a collection (for arrays, etc.)
- Allow a conditional choice of pointers as a collection (for strings in storage)

- Define an expression schema for writing offsets, etc. in terms of the computation of some expression
- Allow referencing regions by name in these expressions
- Allow expressions to include arithmetic operations and a few other builtins ($keccak256, e.g.)