### PR TITLE
Export schemas at type-level and improve a few other things slightly

### DIFF
--- a/packages/format/bin/generate-schema-yamls.js
+++ b/packages/format/bin/generate-schema-yamls.js
@@ -29,6 +29,9 @@ const readSchemaYamls = (directory) => {
 }
 
 const schemaYamls = readSchemaYamls(schemasRoot);
+const rawSchemas = Object.entries(schemaYamls)
+  .map(([id, yaml]) => ({ [id]: YAML.parse(yaml) }))
+  .reduce((a, b) => ({ ...a, ...b }), {});
 
 console.log(`export type SchemaYamlsById = {
   [id: string]: string;
@@ -37,4 +40,11 @@ console.log(`export type SchemaYamlsById = {
 export const schemaYamls: SchemaYamlsById = ${
   JSON.stringify(schemaYamls, undefined, 2)
 };
+
+const rawSchemas = ${
+  JSON.stringify(rawSchemas, undefined, 2)
+} as const;
+
+export type Schema<Id extends keyof typeof rawSchemas> =
+  (typeof rawSchemas)[Id];
 `);

--- a/packages/format/src/index.ts
+++ b/packages/format/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./describe";
-export { schemas, schemaIds } from "./schemas";
+export { schemas, schemaIds, type Schema } from "./schemas";

--- a/packages/format/src/schemas.ts
+++ b/packages/format/src/schemas.ts
@@ -1,5 +1,6 @@
-import { schemaYamls } from "../yamls";
 import { describeSchema } from "./describe";
+import { schemaYamls } from "../yamls";
+export type { Schema } from "../yamls";
 
 export const schemaIds: string[] = Object.keys(schemaYamls);
 export const schemas = schemaIds

--- a/packages/web/spec/type/concepts.mdx
+++ b/packages/web/spec/type/concepts.mdx
@@ -3,10 +3,8 @@ sidebar_position: 2
 ---
 
 import SchemaViewer from "@site/src/components/SchemaViewer";
-import TOCInline from '@theme/TOCInline';
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import yaml from "yaml-template";
 
 # Key concepts
 

--- a/packages/web/src/components/SchemaViewer.tsx
+++ b/packages/web/src/components/SchemaViewer.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import type { URL } from "url";
 import JSONSchemaViewer from "@theme/JSONSchemaViewer";
 import CodeBlock from "@theme/CodeBlock";
 import Tabs from "@theme/Tabs";
@@ -44,7 +46,7 @@ export default function SchemaViewer(props: SchemaViewerProps): JSX.Element {
               jsonPointer: pointer,
               resolvers: {
                 schema: {
-                  resolve: (uri) => {
+                  resolve: (uri: URL) => {
                     const id = uri.toString();
                     const { schema } = describeSchema({
                       schema: { id }
@@ -56,7 +58,7 @@ export default function SchemaViewer(props: SchemaViewerProps): JSX.Element {
             }}
             viewerOptions={{
               showExamples: true,
-              ValueComponent: ({ value }) => {
+              ValueComponent: ({ value }: { value: unknown }) => {
                 // deal with simple types first
                 if ([
                   "string",
@@ -74,7 +76,7 @@ export default function SchemaViewer(props: SchemaViewerProps): JSX.Element {
                   JSON.stringify(value, undefined, 2)
                 }`}</CodeBlock>;
               },
-              DescriptionComponent: ({description}) =>
+              DescriptionComponent: ({description}: { description: string }) =>
                 <ReactMarkdown children={description} />
             }} />
           </SchemaContext.Provider>
@@ -90,8 +92,8 @@ function insertIds<T>(obj: T, rootId: string): T {
   if (Array.isArray(obj)) {
     return obj.map((item, index) => insertIds(item, `${rootId}/${index}`)) as T;
   } else if (obj !== null && typeof obj === 'object') {
-    return Object.keys(obj).reduce((newObj, key) => {
-      const value = obj[key];
+    return Object.entries(obj).reduce((newObj, [key, value]) => {
+      // @ts-ignore
       newObj[key] = insertIds(value, `${rootId}/${key}`);
       return newObj;
     }, {


### PR DESCRIPTION
This PR adds a `Schema<Id>` helper type as an export of @ethdebug/format. This provides all the schemas at the type-level (e.g., `Schema<"schema:ethdebug/format/type">` equals `{ readonly $schema: string; readonly $id: string; /* ... */ }`).

This sort of thing is necessary because TypeScript is not capable of inferring `const` types except for value literals... so this PR modifies the existing schema-to-module codegen process to stringify each schema as an object literal (in addition to the existing output of all the YAMLs as string literals). This new object dump is initialized with our friend `as const`.

Anyway, this sort of thing is a bit extraneous, but I figured it couldn't hurt. Having these raw schema const types is necessary for certain general-purpose solutions like [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts), although I was unable to get that package working with these schemas (it seems like a lot of people are having trouble with their recent releases).

In addition, this PR has a few other code improvements that have been polluting my draft `pointer-schema` branch, so I'm including them here.