### PR TITLE
Improve display of schemas with mutually-exclusive required properties

### DIFF
--- a/packages/web/src/theme/JSONSchemaViewer/JSONSchemaElements/schemaComposition/ExclusiveRequiredPropertiesSchema.tsx
+++ b/packages/web/src/theme/JSONSchemaViewer/JSONSchemaElements/schemaComposition/ExclusiveRequiredPropertiesSchema.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import type { JSONSchema } from "json-schema-typed/draft-2020-12"
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+import { CreateNodes } from "@theme-original/JSONSchemaViewer/components"
+import {
+  SchemaHierarchyContextProvider,
+  useSchemaHierarchyContext,
+} from "@theme-original/JSONSchemaViewer/contexts"
+
+export interface Exclusions {
+  propertyNames: string[];
+  schemasByPropertyName: {
+    [propertyName: string]: {
+      schema: JSONSchema & { type: "object" };
+      index: number;
+    }
+  }
+}
+
+export interface ExclusiveRequiredPropertiesSchemaProps extends Exclusions {
+}
+
+export default function ExcusiveRequiredPropertiesSchema({
+  propertyNames,
+  schemasByPropertyName
+}: ExclusiveRequiredPropertiesSchemaProps): JSX.Element {
+  const { jsonPointer: currentJsonPointer, level: currentLevel } =
+    useSchemaHierarchyContext()
+
+  return (
+    <div>
+      <hr />
+      <span className="badge badge--info">mutually-exclusive required properties</span>&nbsp;
+      This object must specify exactly one of the following:
+      <ul>
+        {propertyNames.map((propertyName, index) =>
+          <li key={index}><code>{propertyName}</code></li>
+        )}
+      </ul>
+
+      Depending on which required property is used, one of the following
+      sub-schemas applies:
+
+      <Tabs>{
+        Object.entries(schemasByPropertyName)
+          .map(([propertyName, { schema, index }]) => (
+            <TabItem
+              key={propertyName}
+              label={("title" in schema && typeof schema.title === "string" && schema.title) || propertyName}
+              value={propertyName}
+            >
+              <SchemaHierarchyContextProvider
+                value={{
+                  level: currentLevel + 1,
+                  jsonPointer: `${currentJsonPointer}/allOf/${index + 1}/then`
+                }}
+              >
+                <CreateNodes schema={schema} />
+              </SchemaHierarchyContextProvider>
+            </TabItem>
+          ))
+      }</Tabs>
+
+    </div>
+  );
+}
+
+
+export function detectExclusiveRequiredProperties(schema: {
+  allOf: JSONSchema[]
+}): Exclusions | undefined {
+  const { allOf } = schema;
+
+  // look for the first clause in an `allOf` to be a `oneOf` different
+  // required properties
+
+  const [firstClause, ...conditionals] = allOf;
+  if (typeof firstClause === "boolean" || !("oneOf" in firstClause)) {
+    return;
+  }
+
+  const { oneOf } = firstClause;
+
+  if (
+    !oneOf ||
+    !oneOf.every(
+      (clause: JSONSchema): clause is { required: [string] } => (
+        typeof clause === "object" &&
+        "required" in clause &&
+        clause.required instanceof Array &&
+        clause.required.length === 1
+      )
+    )
+  ) {
+    return;
+  }
+
+  const propertyNames = (
+    oneOf as (JSONSchema & { required: [propertyName: string] })[]
+  )
+    .map(({ required: [propertyName] }) => propertyName);
+
+  // check that there is one conditional for each `oneOf` required
+  // property and that the conditional is the right kind of if/then
+
+  if (conditionals.length !== propertyNames.length) {
+    return;
+  }
+
+  const allIfThen = conditionals.every(
+    (clause: JSONSchema): clause is { "if": JSONSchema; then: JSONSchema } => {
+      if (typeof clause === "boolean") {
+        return false;
+      }
+
+      const { title, description, "if": if_, then, ...others } = clause;
+
+      return !!if_ && !!then && Object.keys(others).length === 0;
+    }
+  )
+
+  if (!allIfThen) {
+    return;
+  }
+
+  const allIfsIndicateASingleRequiredProperty = conditionals.every(
+    (ifThen: { "if": JSONSchema; then: JSONSchema }): ifThen is {
+      "if": {
+        required: [string];
+      };
+      then: any;
+    } => {
+      const { "if": if_ } = ifThen;
+
+      if (typeof if_ === "boolean" || !("required" in if_)) {
+        return false;
+      }
+
+      const { required } = if_;
+
+      if (!required || required.length !== 1) {
+        return false;
+      }
+
+      const [propertyName] = required;
+
+      return typeof propertyName === "string" && !!propertyName;
+    }
+  );
+
+  if (!allIfsIndicateASingleRequiredProperty) {
+    return;
+  }
+
+  const schemasByPropertyName = conditionals
+    .map(
+      (
+        {
+          "if": { required: [propertyName] },
+          then
+        },
+        index
+      ) => ({
+        [propertyName]: {
+          schema: then,
+          index
+        }
+      })
+    )
+    .reduce((a, b) => ({ ...a, ...b }), {});
+
+  return {
+    propertyNames,
+    schemasByPropertyName
+  };
+}
+

--- a/packages/web/src/theme/JSONSchemaViewer/JSONSchemaElements/schemaComposition/allOfSchema.tsx
+++ b/packages/web/src/theme/JSONSchemaViewer/JSONSchemaElements/schemaComposition/allOfSchema.tsx
@@ -6,6 +6,10 @@ import DiscriminatorSchema, {
   detectDiscriminator
 } from "./DiscriminatorSchema";
 
+import ExclusiveRequiredPropertiesSchema, {
+  detectExclusiveRequiredProperties
+} from "./ExclusiveRequiredPropertiesSchema";
+
 export default function allOfSchemaWrapper(props: {
   schema: Exclude<JSONSchema, boolean> & { allOf: JSONSchema[]; }
 }) {
@@ -14,6 +18,11 @@ export default function allOfSchemaWrapper(props: {
   const discriminator = detectDiscriminator(schema);
   if (discriminator) {
     return <DiscriminatorSchema {...discriminator} />
+  }
+
+  const exclusions = detectExclusiveRequiredProperties(schema);
+  if (exclusions) {
+    return <ExclusiveRequiredPropertiesSchema {...exclusions} />
   }
 
   return (


### PR DESCRIPTION
- Assume the pattern
  ```yaml
  allOf:
    - oneOf:
        - required:
            - ...
        - ...
    - if:
        required:
            - ...
      then:
        ...
    - ...
  ```
  to be the canonical form for ethdebug/format schemas to represent the concept of schemas that are defined with different subschemas depending on which set of mutually-exclusive required properties are included

- Detect this pattern

- Display it with custom wording instead of the default docusaurus-json-schema-plugin presentation of `allOf`s and such
<img width="866" alt="Screenshot 2024-02-05 at 23 51 06" src="https://github.com/ethdebug/format/assets/151065/5e5f5db8-1bbd-486a-91ed-85a9a5051286">

