### PR TITLE
Improve schema extension rendering

### DIFF
--- a/packages/web/src/contexts/SchemaContext.tsx
+++ b/packages/web/src/contexts/SchemaContext.tsx
@@ -1,6 +1,17 @@
 import { useContext, createContext } from "react";
+import type { JSONSchema } from "json-schema-typed/draft-2020-12";
+
 import type { SchemaInfo } from "@ethdebug/format";
 import type { SchemaIndex } from "@site/src/schemas";
+
+export type JSONSchemaWithInternalIdKeys =
+  | boolean
+  | (
+      & Exclude<JSONSchema, boolean>
+      & {
+          [internalIdKey]: string;
+        }
+    );
 
 export interface SchemaContextValue {
   rootSchemaInfo?: SchemaInfo;

--- a/packages/web/src/theme/JSONSchemaViewer/components/CreateNodes.tsx
+++ b/packages/web/src/theme/JSONSchemaViewer/components/CreateNodes.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import CreateTypes from "@theme-original/JSONSchemaViewer/components/CreateTypes";
 import CreateNodes from '@theme-original/JSONSchemaViewer/components/CreateNodes';
-import type { JSONSchema } from "json-schema-typed/draft-2020-12";
 import { useSchemaHierarchyContext } from "@theme-original/JSONSchemaViewer/contexts";
-import { useSchemaContext, internalIdKey } from "@site/src/contexts/SchemaContext";
+import {
+  useSchemaContext,
+  internalIdKey,
+  type JSONSchemaWithInternalIdKeys as JSONSchema
+} from "@site/src/contexts/SchemaContext";
 import Link from "@docusaurus/Link";
 
 import UnnecessaryCompositionSchema, {
@@ -11,9 +14,7 @@ import UnnecessaryCompositionSchema, {
 } from "./UnnecessaryComposition";
 
 export default function CreateNodesWrapper(props: {
-  schema: Exclude<JSONSchema, boolean> & {
-    [internalIdKey]: string
-  }
+  schema: Exclude<JSONSchema, boolean>
 }) {
   const { level } = useSchemaHierarchyContext();
   const { schemaIndex } = useSchemaContext();


### PR DESCRIPTION
- Link directly to schemas with doc section links in index
- Ignore matching `type`s when determining if `type` is included for semantic purposes in an extension schema
- Cleanup imports and define a handy type for schemas with internal IDs