### PR TITLE
Address specification deficiency around expression bytes width

### DIFF
--- a/packages/pointers/src/data.ts
+++ b/packages/pointers/src/data.ts
@@ -58,4 +58,30 @@ export class Data extends Uint8Array {
   toHex(): string {
     return `0x${toHex(this)}`;
   }
+
+  padUntilAtLeast(length: number): Data {
+    if (this.length >= length) {
+      return this;
+    }
+
+    const padded = new Uint8Array(length);
+    padded.set(this, length - this.length);
+    return Data.fromBytes(padded);
+  }
+
+  resizeTo(length: number): Data {
+    if (this.length === length) {
+      return this;
+    }
+
+    const resized = new Uint8Array(length);
+
+    if (this.length < length) {
+      resized.set(this, length - this.length);
+    } else {
+      resized.set(this.slice(this.length - length));
+    }
+
+    return Data.fromBytes(resized);
+  }
 }

--- a/packages/pointers/src/dereference/index.test.ts
+++ b/packages/pointers/src/dereference/index.test.ts
@@ -123,7 +123,7 @@ describe("dereference", () => {
         location: "memory",
         offset: Data.fromUint(
           Data.fromNumber(index).asUint() * 32n
-        ),
+        ).padUntilAtLeast(1),
         length: Data.fromNumber(32),
       })
     }

--- a/packages/pointers/src/dereference/process.ts
+++ b/packages/pointers/src/dereference/process.ts
@@ -32,11 +32,6 @@ export async function* processPointer(
   pointer: Pointer,
   options: ProcessOptions
 ): Process {
-  const {
-    regions: oldRegions,
-    variables: oldVariables,
-  } = options;
-
   if (Pointer.isRegion(pointer)) {
     const region = pointer;
 

--- a/packages/pointers/src/evaluate.ts
+++ b/packages/pointers/src/evaluate.ts
@@ -179,13 +179,7 @@ async function evaluateKeccak256(
   options: EvaluateOptions
 ): Promise<Data> {
   const operands = await Promise.all(expression.$keccak256.map(
-    async expression => {
-      const unpaddedData = await evaluate(expression, options);
-      const data = new Data(32);
-      data.set(unpaddedData, 32 - unpaddedData.length);
-
-      return data;
-    }
+    async expression => await evaluate(expression, options)
   ));
 
   // HACK concatenate via string representation

--- a/packages/pointers/src/pointer.test.ts
+++ b/packages/pointers/src/pointer.test.ts
@@ -106,6 +106,11 @@ describe("type guards", () => {
       guard: Pointer.Expression.isKeccak256
     },
     {
+      schema: expressionSchema,
+      pointer: "#/$defs/Resize",
+      guard: Pointer.Expression.isResize
+    },
+    {
       schema: {
         id: "schema:ethdebug/format/pointer/region"
       },

--- a/packages/pointers/src/pointer.ts
+++ b/packages/pointers/src/pointer.ts
@@ -211,7 +211,8 @@ export namespace Pointer {
     | Expression.Arithmetic
     | Expression.Lookup
     | Expression.Read
-    | Expression.Keccak256;
+    | Expression.Keccak256
+    | Expression.Resize;
 
   export const isExpression = (value: unknown): value is Expression =>
     [
@@ -221,7 +222,8 @@ export namespace Pointer {
       Expression.isArithmetic,
       Expression.isLookup,
       Expression.isRead,
-      Expression.isKeccak256
+      Expression.isKeccak256,
+      Expression.isResize
     ].some(guard => guard(value));
 
   export namespace Expression {
@@ -378,5 +380,23 @@ export namespace Pointer {
     }
     export const isKeccak256 =
       makeIsOperation<"$keccak256", Keccak256>("$keccak256", isOperands);
+
+    export type Resize<N extends number = number> = {
+      [K in `$sized${N}`]: Expression;
+    }
+    export const isResize = <N extends number>(
+      value: unknown
+    ): value is Resize<N> => {
+      if (
+        !value ||
+          typeof value !== "object" ||
+          Object.keys(value).length !== 1
+      ) {
+        return false;
+      }
+      const [key] = Object.keys(value);
+
+      return typeof key === "string" && /^\$sized([1-9]+[0-9]*)$/.test(key);
+    }
   }
 }

--- a/packages/pointers/test/ganache.ts
+++ b/packages/pointers/test/ganache.ts
@@ -144,16 +144,15 @@ function toMachineState(
   ): Machine.State.Words => {
     return {
       async read({
-        slot: unpaddedSlot,
+        slot,
         slice: {
           offset = 0n,
           length = 32n
         } = {}
       }) {
-        const slot = new Data(32);
-        slot.set(unpaddedSlot, 32 - unpaddedSlot.length);
-
-        const rawHex = slots[slot.toHex().slice(2) as keyof typeof slots];
+        const rawHex = slots[
+          slot.resizeTo(32).toHex().slice(2) as keyof typeof slots
+        ];
 
         const data = Data.fromHex(`0x${rawHex}`);
 

--- a/packages/web/docs/implementation-guides/pointers/evaluating-expressions.mdx
+++ b/packages/web/docs/implementation-guides/pointers/evaluating-expressions.mdx
@@ -126,6 +126,20 @@ Evaluating remainders:
     sourceFile => sourceFile.getFunction("evaluateArithmeticRemainder")
   } />
 
+## Evaluating resize expressions
+
+This schema provides the `{ "$sized<N>": <expression> }` construct to allow
+explicitly resizing a subexpression. This implementation uses the
+[`Data.prototype.resizeTo()`](/docs/implementation-guides/pointers/types/data-and-machines)
+method to perform this operation.
+
+<CodeListing
+  packageName="@ethdebug/pointers"
+  sourcePath="src/evaluate.ts"
+  extract={
+    sourceFile => sourceFile.getFunction("evaluateResize")
+  } />
+
 ## Evaluating keccak256 hashes
 
 Many data types in storage are addressed by way of keccak256 hashing. This
@@ -136,15 +150,6 @@ See Solidity's
 [Layout of State Variables in Storage](https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html)
 documentation for an example of how one high-level EVM language makes heavy
 use of hashing to allocate persistent data.
-
-:::warning
-This area of the schema is likely incomplete and could still use additional
-specification. Be warned that, while this implementation may match the schema
-itself, it may not be fully sufficient for expressing all kinds of data
-allocations.
-
-Please stay tuned as this work continues being refined.
-:::
 
 <CodeListing
   packageName="@ethdebug/pointers"

--- a/packages/web/spec/pointer/expression.mdx
+++ b/packages/web/spec/pointer/expression.mdx
@@ -33,7 +33,7 @@ assumed to be left-padded to the bytes width appropriate for the context.
   pointer="#/$defs/Literal"
   />
 
-## Scalar variables
+## Variables
 
 An expression can be a string value equal to the identifier for a known
 scalar variable introduced by some pointer representation.
@@ -43,7 +43,7 @@ For an example where scalar variables may appear, see the
 
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/pointer/expression" }}
-  pointer="#/$defs/Literal"
+  pointer="#/$defs/Variable"
   />
 
 ## Arithmetic operations

--- a/packages/web/spec/pointer/expression.mdx
+++ b/packages/web/spec/pointer/expression.mdx
@@ -92,6 +92,18 @@ hash of the concatenation of bytes specified by the list.
   pointer="#/$defs/Keccak256"
   />
 
+## Resize operations
+
+In certain situations, e.g. keccak256 hashes, it's crucially important to be
+able to express the bytes width of particular expression values. This schema
+provides primitives to allow specifying an explicit bytes width for a
+particular sub-expression.
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/pointer/expression" }}
+  pointer="#/$defs/Resize"
+  />
+
 ## Region references
 
 Regions can be referenced either by name (which **must** be a defined region),

--- a/packages/web/src/schemas.ts
+++ b/packages/web/src/schemas.ts
@@ -121,9 +121,9 @@ export const schemaIndex: SchemaIndex = {
     href: "/spec/pointer/expression#literal-values"
   },
 
-  "schema:ethdebug/format/pointer/expression#/$defs/Scalar": {
-    title: "Scalar variable expression schema",
-    href: "/spec/pointer/expression#scalar-variables"
+  "schema:ethdebug/format/pointer/expression#/$defs/Variable": {
+    title: "Variable expression schema",
+    href: "/spec/pointer/expression#variables"
   },
 
   "schema:ethdebug/format/pointer/expression#/$defs/Arithmetic": {

--- a/packages/web/src/schemas.ts
+++ b/packages/web/src/schemas.ts
@@ -116,40 +116,42 @@ export const schemaIndex: SchemaIndex = {
     href: "/spec/pointer/expression"
   },
 
-  "schema:ethdebug/format/pointer/expression#/$defs/Literal": {
-    title: "Literal values schema",
-    href: "/spec/pointer/expression#literal-values"
-  },
+  ...Object.entries({
+    Literal: {
+      title: "Literal values schema",
+      anchor: "#literal-values"
+    },
+    Variable: {
+      title: "Variable expression schema",
+      anchor: "#variables"
+    },
+    Arithmetic: {
+      title: "Arithmetic operation expression schema",
+      anchor: "#arithmetic-operations"
+    },
+    Lookup: {
+      title: "Lookup expression schema",
+      anchor: "#lookup-region-definition"
+    },
+    Read: {
+      title: "Read expression schema",
+      anchor: "#reading-from-the-evm"
+    },
+    Keccak256: {
+      title: "Keccak256 hash expression schema",
+      anchor: "#keccak256-hashes"
+    },
+    Reference: {
+      title: "Region reference",
+      anchor: "#region-references"
+    },
+  }).map(([def, { title, anchor }]) => ({
+    [`schema:ethdebug/format/pointer/expression#/$defs/${def}`]: {
+      title,
+      href: `/spec/pointer/expression${anchor}`
+    }
+  })).reduce((a, b) => ({ ...a, ...b }), {}),
 
-  "schema:ethdebug/format/pointer/expression#/$defs/Variable": {
-    title: "Variable expression schema",
-    href: "/spec/pointer/expression#variables"
-  },
-
-  "schema:ethdebug/format/pointer/expression#/$defs/Arithmetic": {
-    title: "Arithmetic operation expression schema",
-    href: "/spec/pointer/expression#arithmetic-operations"
-  },
-
-  "schema:ethdebug/format/pointer/expression#/$defs/Lookup": {
-    title: "Lookup expression schema",
-    href: "/spec/pointer/expression#lookup-region-definition"
-  },
-
-  "schema:ethdebug/format/pointer/expression#/$defs/Read": {
-    title: "Read expression schema",
-    href: "/spec/pointer/expression#reading-from-the-evm"
-  },
-
-  "schema:ethdebug/format/pointer/expression#/$defs/Keccak256": {
-    title: "Keccak256 hash expression schema",
-    href: "/spec/pointer/expression#keccak256-hashes"
-  },
-
-  "schema:ethdebug/format/pointer/expression#/$defs/Reference": {
-    title: "Region reference",
-    href: "/spec/pointer/expression#region-references"
-  },
 
   "schema:ethdebug/format/materials/id": {
     title: "Identifier schema",

--- a/packages/web/src/schemas.ts
+++ b/packages/web/src/schemas.ts
@@ -141,6 +141,10 @@ export const schemaIndex: SchemaIndex = {
       title: "Keccak256 hash expression schema",
       anchor: "#keccak256-hashes"
     },
+    Resize: {
+      title: "Resize operation schema",
+      anchor: "#resize-operations"
+    },
     Reference: {
       title: "Region reference",
       anchor: "#region-references"

--- a/schemas/pointer.schema.yaml
+++ b/schemas/pointer.schema.yaml
@@ -193,7 +193,8 @@ examples:
                   - 2
 
               "start-slot":
-                $keccak256: ["contract-variable-slot"]
+                $keccak256:
+                  - $sized32: "contract-variable-slot"
 
               "total-slots":
                 # account for both zero and nonzero slot remainders by adding

--- a/schemas/pointer/expression.schema.yaml
+++ b/schemas/pointer/expression.schema.yaml
@@ -177,7 +177,7 @@ $defs:
   Keccak256:
     title: Keccak256 hash
     description: |
-      An object of the form `{ "keccak256": [...values] }`, indicating that this
+      An object of the form `{ "$keccak256": [...values] }`, indicating that this
       expression evaluates to the Solidity-style keccak256 hash of the
       tightly-packed bytes encoded by `values`.
     type: object

--- a/schemas/pointer/expression.schema.yaml
+++ b/schemas/pointer/expression.schema.yaml
@@ -13,6 +13,7 @@ oneOf:
   - $ref: "#/$defs/Lookup"
   - $ref: "#/$defs/Read"
   - $ref: "#/$defs/Keccak256"
+  - $ref: "#/$defs/Resize"
 
 $defs:
   Literal:
@@ -194,6 +195,38 @@ $defs:
       - $keccak256:
           - 0
           - "0x00"
+
+  Resize:
+    title: Resize data
+    description: |
+      An object of the form `{ "$sized<N>": <expression> }`, where `<N>` is the
+      smallest decimal representation of an unsigned integer and where
+      `<expression>` is another expression.
+
+      This object's value is evaluated as follows, based on the number
+      represented by `<N>` and the bytes width of `<expression>`:
+      - If the width equals `<N>`, this object evalutes to the same value as
+        `<expression>` (equivalent to the identity function or no-op).
+      - If the width is less than `<N>`, this object evalutes to the same value
+        as `<expression>` but with additional zero-bytes (`0x00`) prepended on
+        the left (most significant) side, such that the resulting bytes width
+        equals `<N>`.
+      - If the width exceeds `<N>`, this object evalutes to the same value
+        as `<expression>` but with a number of bytes removed from the left
+        (most significant) side until the bytes width equals `<N>`.
+
+      (These cases match the behavior that Solidity uses for resizing its
+      `bytesN`/`uintN` types.)
+    type: object
+    additionalProperties: false
+    patternProperties:
+      "^\\$sized([1-9]+[0-9]*)$":
+        $ref: "schema:ethdebug/format/pointer/expression"
+    minProperties: 1
+    maxProperties: 1
+    examples:
+      - $sized2: "0x00" # 0x0000
+      - $sized2: "0xffffff" # 0xffff
 
 examples:
   - 0


### PR DESCRIPTION
The **ethdebug/format/pointer/expression** did not define any notion of bytes width for any expressions, leaving it to implementors to guess how many bytes should be used when representing the evaluation of a given expression.

This PR addresses that concern by defining an explicit `{ "$sized<N>": <expression> }` expression that resolves to the resized (left-padded or left-truncated) equivalent of its subexpression.