### PR TITLE
Remove autogenerated category pages from spec

### DIFF
--- a/packages/web/spec/data/_category_.json
+++ b/packages/web/spec/data/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "ethdebug/format/data",
   "position": 5,
-  "link": {
-    "type": "generated-index",
-    "description": "Work-in-progress formal schema for ethdebug format"
-  }
+  "link": null
 }

--- a/packages/web/spec/materials/_category_.json
+++ b/packages/web/spec/materials/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "ethdebug/format/materials",
   "position": 5,
-  "link": {
-    "type": "generated-index",
-    "description": "Work-in-progress formal schema for ethdebug format"
-  }
+  "link": null
 }

--- a/packages/web/spec/pointer/_category_.json
+++ b/packages/web/spec/pointer/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "ethdebug/format/pointer",
   "position": 4,
-  "link": {
-    "type": "generated-index",
-    "description": "Work-in-progress formal schema for ethdebug format"
-  }
+  "link": null
 }

--- a/packages/web/spec/pointer/collection/_category_.json
+++ b/packages/web/spec/pointer/collection/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "Collections",
   "position": 5,
-  "link": {
-    "type": "generated-index",
-    "description": "Work-in-progress formal schema for ethdebug format"
-  }
+  "link": null
 }

--- a/packages/web/spec/pointer/region/_category_.json
+++ b/packages/web/spec/pointer/region/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "Regions",
   "position": 4,
-  "link": {
-    "type": "generated-index",
-    "description": "Work-in-progress formal schema for ethdebug format"
-  }
+  "link": null
 }

--- a/packages/web/spec/type/_category_.json
+++ b/packages/web/spec/type/_category_.json
@@ -1,8 +1,5 @@
 {
   "label": "ethdebug/format/type",
   "position": 3,
-  "link": {
-    "type": "generated-index",
-    "description": "Work-in-progress formal schema for ethdebug format"
-  }
+  "link": null
 }


### PR DESCRIPTION
... since these pages are rather useless without adding proper descriptions for everything.