### PR TITLE
Allow overriding Docusaurus baseUrl

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build website
-        run: yarn build
+        run: BASE_URL='/format/' yarn build
         working-directory: ./packages/web
 
       - name: Deploy to GitHub Pages

--- a/packages/web/docusaurus.config.ts
+++ b/packages/web/docusaurus.config.ts
@@ -4,6 +4,8 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import type { Configuration } from "webpack";
 
+const baseUrl = process.env["BASE_URL"] || "/";
+
 const config: Config = {
   title: 'ethdebug format',
   tagline: 'Debugging data format for smart contracts',
@@ -14,7 +16,7 @@ const config: Config = {
 
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/format/',
+  baseUrl,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
- Use just `/` as default baseUrl
- Update gh-pages action to override this