### PR TITLE
Fix misspelled word

### DIFF
--- a/packages/web/docs/sketches/layout.mdx
+++ b/packages/web/docs/sketches/layout.mdx
@@ -468,7 +468,7 @@ of a flag for row-major vs column-major order.  Probably best to just exclude th
 > Oh, geez, I just realized there's something big I left out: How things are
 > pointed to on the stack.  Actually, one could perhaps speak of cross-location
 > pointers in general, but as that doesn't exist mostly at the moment, probably
-> no sense in includng that; it's premature.
+> no sense in including that; it's premature.
 >
 > But, I guess something that needs to be added is, for each type, for the
 > stack location, I talked about from/to but really we also need to say, does


### PR DESCRIPTION
update with minor typo.
![image](https://github.com/user-attachments/assets/5f8bfd24-3576-40b9-99a1-caae4fab398d)
