### PR TITLE
Define polymorphic value schema for numbers

### DIFF
--- a/packages/web/spec/data/overview.mdx
+++ b/packages/web/spec/data/overview.mdx
@@ -26,5 +26,6 @@ These schemas (like all schemas in this format) are specified as
 Please refer to the following resources in this section, or see the navigation
 bar for complete contents.
 
+- [Non-negative numeric values](/spec/data/value)
 - [Hexadecimal strings](/spec/data/hex)
 - [Unsigned integer](/spec/data/unsigned)

--- a/packages/web/spec/data/value.mdx
+++ b/packages/web/spec/data/value.mdx
@@ -1,0 +1,11 @@
+---
+sidebar_position: 2
+---
+
+import SchemaViewer from "@site/src/components/SchemaViewer";
+
+# Non-negative numeric values
+
+<SchemaViewer
+  schema={{ id: "schema:ethdebug/format/data/value" }}
+  />

--- a/packages/web/src/schemas.ts
+++ b/packages/web/src/schemas.ts
@@ -163,7 +163,7 @@ const pointerSchemaIndex: SchemaIndex = {
   })).reduce((a, b) => ({ ...a, ...b }), {}),
 };
 
-const dataSchemaIndex: SchemaIndex = ["hex", "unsigned"].map(name => ({
+const dataSchemaIndex: SchemaIndex = ["value", "hex", "unsigned"].map(name => ({
   [`schema:ethdebug/format/data/${name}`]: {
     href: `/spec/data/${name}`
   }

--- a/schemas/data/value.schema.yaml
+++ b/schemas/data/value.schema.yaml
@@ -1,0 +1,20 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/data/value"
+
+title: ethdebug/format/data/value
+description: |
+  A non-negative integer value, expressed either as a native JSON number or as
+  a `0x`-prefixed hexadecimal string.
+
+oneOf:
+  - description: A non-negative integer literal
+    $ref: "schema:ethdebug/format/data/unsigned"
+
+  - description: |
+      A `0x`-prefixed hexadecimal string representing literal bytes or a number
+      commonly displayed in base 16 (e.g. bytecode instruction offsets).
+    $ref: "schema:ethdebug/format/data/hex"
+
+examples:
+  - "0x0000"
+  - 2

--- a/schemas/materials/source-range.schema.yaml
+++ b/schemas/materials/source-range.schema.yaml
@@ -35,11 +35,11 @@ properties:
       offset:
         description: |
           Byte offset at beginning of range.
-        $ref: "schema:ethdebug/format/data/unsigned"
+        $ref: "schema:ethdebug/format/data/value"
 
       length:
         description: Number of bytes contained in range
-        $ref: "schema:ethdebug/format/data/unsigned"
+        $ref: "schema:ethdebug/format/data/value"
 
     unevaluatedProperties: false
 

--- a/schemas/pointer/expression.schema.yaml
+++ b/schemas/pointer/expression.schema.yaml
@@ -21,13 +21,7 @@ $defs:
     description: |
       An unsigned number or a `0x`-prefixed string of hexadecimal digits
 
-    oneOf:
-      - description: A non-negative integer literal
-        $ref: "schema:ethdebug/format/data/unsigned"
-
-      - description: |
-          A `0x`-prefixed hexadecimal string representing literal bytes
-        $ref: "schema:ethdebug/format/data/hex"
+    $ref: "schema:ethdebug/format/data/value"
 
     examples:
       - 5

--- a/schemas/program/instruction.schema.yaml
+++ b/schemas/program/instruction.schema.yaml
@@ -18,9 +18,7 @@ properties:
       instruction's program counter. For EOF bytecode, this value **must** be
       the offset from the start of the container, not the start of a particular
       code section within that container.
-    oneOf:
-      - $ref: "schema:ethdebug/format/data/unsigned"
-      - $ref: "schema:ethdebug/format/data/hex"
+    $ref: "schema:ethdebug/format/data/value"
 
   operation:
     title: Machine operation information
@@ -36,9 +34,9 @@ properties:
         minItems: 1
         items:
           description: |
-            An immediate value, specified as a `0x`-prefixed hexadecimal string.
-          type: string
-          pattern: "^0x[0-9a-fA-F]{1,}$"
+            An immediate value specified as argument to the opcode
+          $ref: "schema:ethdebug/format/data/value"
+
     required:
       - mnemonic
 


### PR DESCRIPTION
To avoid schemas needing to use `oneOf` on the existing unsigned/hex schemas.