### PR TITLE
Make variables contexts a bit more strict

### DIFF
--- a/schemas/program/context/variables.schema.yaml
+++ b/schemas/program/context/variables.schema.yaml
@@ -70,6 +70,9 @@ $defs:
           Allocation information for the variable, if it exists.
         $ref: "schema:ethdebug/format/pointer"
 
+    minProperties: 1
+    unevaluatedProperties: false
+
     examples:
       - identifier: x
         declaration:


### PR DESCRIPTION
- Require at least one property for each variable
- Disallow other properties in variable