### PR TITLE
Improve ergonomics of the `describeSchema()` function used everywhere

### DIFF
--- a/packages/format/src/types/data/index.test.ts
+++ b/packages/format/src/types/data/index.test.ts
@@ -7,21 +7,15 @@ import { Data } from "./index.js";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/data/value"
-      },
+      schema: "schema:ethdebug/format/data/value",
       guard: Data.isValue
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/data/unsigned"
-      },
+      schema: "schema:ethdebug/format/data/unsigned",
       guard: Data.isUnsigned
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/data/hex"
-      },
+      schema: "schema:ethdebug/format/data/hex",
       guard: Data.isHex
     },
   ] as const;

--- a/packages/format/src/types/materials/index.test.ts
+++ b/packages/format/src/types/materials/index.test.ts
@@ -7,40 +7,30 @@ import { Materials } from "./index";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/materials/id"
-      },
+      schema: "schema:ethdebug/format/materials/id",
       guard: Materials.isId
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/materials/reference"
-      },
+      schema: "schema:ethdebug/format/materials/reference",
       guard: Materials.isReference
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/materials/compilation"
-      },
+      schema: "schema:ethdebug/format/materials/compilation",
       guard: Materials.isCompilation
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/materials/source"
-      },
+      schema: "schema:ethdebug/format/materials/source",
       guard: Materials.isSource
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/materials/source-range"
-      },
+      schema: "schema:ethdebug/format/materials/source-range",
       guard: Materials.isSourceRange
     },
   ] as const;
 
   for (const { guard, ...describeSchemaOptions } of schemaGuards) {
     const { schema } = describeSchemaOptions;
-    describe(schema.id.slice("schema:".length), () => {
+    describe(schema.slice("schema:".length), () => {
       it("matches its examples", () => {
         const {
           schema: {

--- a/packages/format/src/types/pointer/pointer.test.ts
+++ b/packages/format/src/types/pointer/pointer.test.ts
@@ -5,9 +5,7 @@ import { describeSchema } from "../../describe";
 import { Pointer, isPointer } from "./pointer";
 
 describe("type guards", () => {
-  const expressionSchema = {
-    id: "schema:ethdebug/format/pointer/expression"
-  };
+  const expressionSchema = "schema:ethdebug/format/pointer/expression";
 
   const schemaGuards = [
     {
@@ -60,75 +58,51 @@ describe("type guards", () => {
       guard: Pointer.Expression.isResize
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region"
-      },
+      schema: "schema:ethdebug/format/pointer/region",
       guard: Pointer.isRegion
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/stack"
-      },
+      schema: "schema:ethdebug/format/pointer/region/stack",
       guard: Pointer.Region.isStack
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/memory"
-      },
+      schema: "schema:ethdebug/format/pointer/region/memory",
       guard: Pointer.Region.isMemory
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/storage"
-      },
+      schema: "schema:ethdebug/format/pointer/region/storage",
       guard: Pointer.Region.isStorage
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/calldata"
-      },
+      schema: "schema:ethdebug/format/pointer/region/calldata",
       guard: Pointer.Region.isCalldata
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/returndata"
-      },
+      schema: "schema:ethdebug/format/pointer/region/returndata",
       guard: Pointer.Region.isReturndata
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/transient"
-      },
+      schema: "schema:ethdebug/format/pointer/region/transient",
       guard: Pointer.Region.isTransient
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/region/code"
-      },
+      schema: "schema:ethdebug/format/pointer/region/code",
       guard: Pointer.Region.isCode
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/collection/group"
-      },
+      schema: "schema:ethdebug/format/pointer/collection/group",
       guard: Pointer.Collection.isGroup
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/collection/list"
-      },
+      schema: "schema:ethdebug/format/pointer/collection/list",
       guard: Pointer.Collection.isList
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer"
-      },
+      schema: "schema:ethdebug/format/pointer",
       guard: isPointer
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/pointer/template"
-      },
+      schema: "schema:ethdebug/format/pointer/template",
       guard: Pointer.isTemplate
     },
   ] as const;

--- a/packages/format/src/types/program/context.test.ts
+++ b/packages/format/src/types/program/context.test.ts
@@ -7,34 +7,26 @@ import { Context, isContext } from "./context";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/program/context"
-      },
+      schema: "schema:ethdebug/format/program/context",
       guard: isContext
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/program/context/code"
-      },
+      schema: "schema:ethdebug/format/program/context/code",
       guard: Context.isCode
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/program/context/variables"
-      },
+      schema: "schema:ethdebug/format/program/context/variables",
       guard: Context.isVariables
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/program/context/remark"
-      },
+      schema: "schema:ethdebug/format/program/context/remark",
       guard: Context.isRemark
     },
   ] as const;
 
   for (const { guard, ...describeSchemaOptions } of schemaGuards) {
     const { schema } = describeSchemaOptions;
-    describe(schema.id.slice("schema:".length), () => {
+    describe(schema.slice("schema:".length), () => {
       it("matches its examples", () => {
         const {
           schema: {

--- a/packages/format/src/types/program/instruction.test.ts
+++ b/packages/format/src/types/program/instruction.test.ts
@@ -7,16 +7,14 @@ import { Instruction, isInstruction } from "./instruction";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/program/instruction"
-      },
+      schema: "schema:ethdebug/format/program/instruction",
       guard: isInstruction
     },
   ] as const;
 
   for (const { guard, ...describeSchemaOptions } of schemaGuards) {
     const { schema } = describeSchemaOptions;
-    describe(schema.id.slice("schema:".length), () => {
+    describe(schema.slice("schema:".length), () => {
       it("matches its examples", () => {
         const {
           schema: {

--- a/packages/format/src/types/program/program.test.ts
+++ b/packages/format/src/types/program/program.test.ts
@@ -7,16 +7,14 @@ import { Program, isProgram } from "./program";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/program"
-      },
+      schema: "schema:ethdebug/format/program",
       guard: isProgram
     },
   ] as const;
 
   for (const { guard, ...describeSchemaOptions } of schemaGuards) {
     const { schema } = describeSchemaOptions;
-    describe(schema.id.slice("schema:".length), () => {
+    describe(schema.slice("schema:".length), () => {
       it("matches its examples", () => {
         const {
           schema: {

--- a/packages/format/src/types/type/base.test.ts
+++ b/packages/format/src/types/type/base.test.ts
@@ -7,23 +7,17 @@ import * as Base from "./base";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/type/base"
-      },
+      schema: "schema:ethdebug/format/type/base",
       pointer: "#/$defs/ElementaryType",
       guard: Base.isElementary
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/base"
-      },
+      schema: "schema:ethdebug/format/type/base",
       pointer: "#/$defs/ComplexType",
       guard: Base.isComplex
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/base"
-      },
+      schema: "schema:ethdebug/format/type/base",
       pointer: "#/$defs/TypeWrapper",
       guard: Base.isWrapper
     },
@@ -32,7 +26,7 @@ describe("type guards", () => {
   for (const { guard, ...describeSchemaOptions } of schemaGuards) {
     const { schema, pointer } = describeSchemaOptions;
     describe(
-      `${schema.id.slice("schema:".length)}${pointer}`,
+      `${schema.slice("schema:".length)}${pointer}`,
       () => {
       it("matches its examples", () => {
         const {

--- a/packages/format/src/types/type/index.test.ts
+++ b/packages/format/src/types/type/index.test.ts
@@ -7,124 +7,88 @@ import { Type, isType } from "./index";
 describe("type guards", () => {
   const schemaGuards = [
     {
-      schema: {
-        id: "schema:ethdebug/format/type"
-      },
+      schema: "schema:ethdebug/format/type",
       guard: isType
     },
 
     // elementary types
 
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary"
-      },
+      schema: "schema:ethdebug/format/type/elementary",
       guard: Type.isElementary
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/uint"
-      },
+      schema: "schema:ethdebug/format/type/elementary/uint",
       guard: Type.Elementary.isUint
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/int"
-      },
+      schema: "schema:ethdebug/format/type/elementary/int",
       guard: Type.Elementary.isInt
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/ufixed"
-      },
+      schema: "schema:ethdebug/format/type/elementary/ufixed",
       guard: Type.Elementary.isUfixed
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/fixed"
-      },
+      schema: "schema:ethdebug/format/type/elementary/fixed",
       guard: Type.Elementary.isFixed
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/bool"
-      },
+      schema: "schema:ethdebug/format/type/elementary/bool",
       guard: Type.Elementary.isBool
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/bytes"
-      },
+      schema: "schema:ethdebug/format/type/elementary/bytes",
       guard: Type.Elementary.isBytes
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/string"
-      },
+      schema: "schema:ethdebug/format/type/elementary/string",
       guard: Type.Elementary.isString
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/address"
-      },
+      schema: "schema:ethdebug/format/type/elementary/address",
       guard: Type.Elementary.isAddress
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/contract"
-      },
+      schema: "schema:ethdebug/format/type/elementary/contract",
       guard: Type.Elementary.isContract
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/elementary/enum"
-      },
+      schema: "schema:ethdebug/format/type/elementary/enum",
       guard: Type.Elementary.isEnum
     },
 
     // complex types
 
     {
-      schema: {
-        id: "schema:ethdebug/format/type/complex"
-      },
+      schema: "schema:ethdebug/format/type/complex",
       guard: Type.isComplex
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/complex/alias"
-      },
+      schema: "schema:ethdebug/format/type/complex/alias",
       guard: Type.Complex.isAlias
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/complex/tuple"
-      },
+      schema: "schema:ethdebug/format/type/complex/tuple",
       guard: Type.Complex.isTuple
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/complex/array"
-      },
+      schema: "schema:ethdebug/format/type/complex/array",
       guard: Type.Complex.isArray
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/complex/mapping"
-      },
+      schema: "schema:ethdebug/format/type/complex/mapping",
       guard: Type.Complex.isMapping
     },
     {
-      schema: {
-        id: "schema:ethdebug/format/type/complex/struct"
-      },
+      schema: "schema:ethdebug/format/type/complex/struct",
       guard: Type.Complex.isStruct
     },
   ] as const;
 
   for (const { guard, ...describeSchemaOptions } of schemaGuards) {
     const { schema } = describeSchemaOptions;
-    describe(schema.id.slice("schema:".length), () => {
+    describe(schema.slice("schema:".length), () => {
       it("matches its examples", () => {
         const {
           schema: {

--- a/packages/web/spec/type/overview.mdx
+++ b/packages/web/spec/type/overview.mdx
@@ -88,7 +88,7 @@ Here are some example **ethdebug/format/type** type representations.
     "ethdebug/format/type/complex/mapping",
     "ethdebug/format/type/complex/struct"
   ].map((id, index) => {
-    const { schema } = describeSchema({ schema: { id: `schema:${id}` } });
+    const { schema } = describeSchema({ schema: `schema:${id}` });
     return <TabItem
       key={index}
       value={index}


### PR DESCRIPTION
Recently-added tests do a whole bunch of schema-lookup using `describeSchema({ schema: { id }, pointer?: string })`, which is overly verbose because `describeSchema()` is very polymorphic to account for all the ways this function gets used in testing code and on the website.

For now, I'm leaving it as "probably pretty useful" that this function is so polymorphic, but I wanted to simplify the syntax for simply obtaining a schema object for a particular ethdebug/format schema, so this PR just adds a new polymorphism, `describeSchema({ schema: string; })` and treats that as equivalent to `schema: { id: string }`.