### PR TITLE
Make some internal changes

### DIFF
--- a/packages/format/.gitignore
+++ b/packages/format/.gitignore
@@ -1,2 +1,2 @@
 dist
-yamls.ts
+src/schemas/yamls.ts

--- a/packages/format/bin/generate-schema-yamls.js
+++ b/packages/format/bin/generate-schema-yamls.js
@@ -33,7 +33,10 @@ const rawSchemas = Object.entries(schemaYamls)
   .map(([id, yaml]) => ({ [id]: YAML.parse(yaml) }))
   .reduce((a, b) => ({ ...a, ...b }), {});
 
-console.log(`export type SchemaYamlsById = {
+console.log(`// THIS FILE GETS AUTO-GENERATED AS PART OF THIS PACKAGE'S BUILD PROCESS
+// Please do not modify it directly or allow it to get checked into source control.
+
+export type SchemaYamlsById = {
   [id: string]: string;
 };
 

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -9,9 +9,9 @@
     "dist"
   ],
   "scripts": {
-    "prepare:yamls": "node ./bin/generate-schema-yamls.js > yamls.ts",
+    "prepare:yamls": "node ./bin/generate-schema-yamls.js > src/schemas/yamls.ts",
     "prepare": "yarn prepare:yamls && tsc",
-    "clean": "rm -rf dist && rm yamls.ts",
+    "clean": "rm -rf dist && rm src/schemas/yamls.ts",
     "test": "node --experimental-vm-modules $(yarn bin jest)",
     "watch:typescript": "tsc --watch",
     "watch:schemas": "nodemon --watch ../../schemas -e 'yaml' --exec 'yarn prepare:yamls'",

--- a/packages/format/src/describe.ts
+++ b/packages/format/src/describe.ts
@@ -1,6 +1,6 @@
 import * as YAML from "yaml";
 
-import { schemaYamls } from "../yamls";
+import { schemaYamls } from "./schemas/yamls";
 
 import type { JSONSchema as JSONSchemaTyped } from "json-schema-typed/draft-2020-12"
 

--- a/packages/format/src/schemas/index.ts
+++ b/packages/format/src/schemas/index.ts
@@ -1,6 +1,6 @@
-import { describeSchema } from "./describe";
-import { schemaYamls } from "../yamls";
-export type { Schema } from "../yamls";
+import { describeSchema } from "../describe";
+import { schemaYamls } from "./yamls";
+export type { Schema } from "./yamls";
 
 export const schemaIds: string[] = Object.keys(schemaYamls);
 export const schemas = schemaIds


### PR DESCRIPTION
(I was trying to get the tests that live in `./packages/tests` to get moved to `./packages/format`, to avoid the need for an extra package, but those tests don't seem to want to run inside a commonjs package, even when doing `await import()` manually. Looks like that's a jest problem, but seems like that's a problem for a different PR)