### PR TITLE
Upgrade @hyperjump/json-schema

### DIFF
--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -11,7 +11,8 @@
   },
   "devDependencies": {
     "@ethdebug/format": "^0.1.0-0",
-    "@hyperjump/json-schema": "1.6.7",
+    "@hyperjump/browser": "^1.2.0",
+    "@hyperjump/json-schema": "^1.11.0",
     "cli-highlight": "^2.1.11",
     "indent-string": "^5.0.0",
     "typescript": "^5.3.3",

--- a/packages/tests/src/loadSchemas.ts
+++ b/packages/tests/src/loadSchemas.ts
@@ -4,6 +4,7 @@ import {
   validate,
   setMetaSchemaOutputFormat,
 } from "@hyperjump/json-schema/draft-2020-12";
+import { BASIC } from "@hyperjump/json-schema/experimental";
 import { bundle } from "@hyperjump/json-schema/bundle";
 import YAML from "yaml";
 import indentString from "indent-string";
@@ -17,7 +18,7 @@ import {
 import schemas from "./schemas.js";
 
 const main = () => {
-  setMetaSchemaOutputFormat("BASIC");
+  setMetaSchemaOutputFormat(BASIC);
 
   for (const schema of Object.values(schemas)) {
     addSchema(schema as any);
@@ -40,15 +41,18 @@ const main = () => {
           ? schema.title
           : schemaReference;
 
-      const output = await validate(schemaReference, received, "DETAILED");
+      const output = await validate(schemaReference, received, BASIC);
 
       const pass = output.valid;
 
       return {
         pass,
-        message: () => `expected ${
-          JSON.stringify(received)
-        } ${
+        message: () => `expected input:\n${
+          indentString(
+            highlight(YAML.stringify(received), { language: "yaml" }),
+            2
+          )
+        }\n${
           pass
             ? "not to be"
             : "to be"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,11 +2731,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz#34aa0b52d0fbb1a654b596acfa595f0c7b77a77b"
   integrity sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==
 
-"@fastify/busboy@^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz"
-  integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
-
 "@fortawesome/fontawesome-common-types@6.5.1":
   version "6.5.1"
   resolved "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz"
@@ -2786,25 +2781,33 @@
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@hyperjump/json-pointer@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@hyperjump/json-pointer/-/json-pointer-1.0.1.tgz"
-  integrity sha512-vV2pSc7JCwbKEMzh8kr/ICZdO+UZbA3aZ7N8t7leDi9cduWKa9yoP5LS04LnsbErlPbUNHvWBFlbTaR/o/uf7A==
+"@hyperjump/browser@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@hyperjump/browser/-/browser-1.2.0.tgz#658eff73b6f177531c1a442f385157d620bba5fc"
+  integrity sha512-xv7u4Ddbhnd9a4yi8V0bNYQrimL0SuBW2T+l4eSEKedxhIBVqxuZ6Vulm6+rPtcvg79LyhWxH4fB/J056qaSMQ==
   dependencies:
+    "@hyperjump/json-pointer" "^1.1.0"
+    "@hyperjump/uri" "^1.2.0"
+    content-type "^1.0.5"
     just-curry-it "^5.3.0"
+    type-is "^1.6.18"
 
-"@hyperjump/json-schema@1.6.7":
-  version "1.6.7"
-  resolved "https://registry.npmjs.org/@hyperjump/json-schema/-/json-schema-1.6.7.tgz"
-  integrity sha512-6ufO5Iov85FBXQ1a//7sQDwzZRoyEMR1MD7Te6k00DvApvj1/x3k/S1RcPmmPCCuj7BDxHVixu4qBTM6sBsmBA==
+"@hyperjump/json-pointer@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@hyperjump/json-pointer/-/json-pointer-1.1.0.tgz#57342cb50a87b4e5d561738cc1d1c9e088780dee"
+  integrity sha512-tFCKxMKDKK3VEdtUA3EBOS9GmSOS4mbrTjh9v3RnK10BphDMOb6+bxTh++/ae1AyfHyWb6R54O/iaoAtPMZPCg==
+
+"@hyperjump/json-schema@^1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@hyperjump/json-schema/-/json-schema-1.11.0.tgz#db02e2ebf48c3e6ac029a6515265af77be0a1689"
+  integrity sha512-gX1YNObOybUW6tgJjvb1lomNbI/VnY+EBPokmEGy9Lk8cgi+gE0vXhX1XDgIpUUA4UXfgHEn5I1mga5vHgOttg==
   dependencies:
-    "@hyperjump/json-pointer" "^1.0.0"
+    "@hyperjump/json-pointer" "^1.1.0"
     "@hyperjump/pact" "^1.2.0"
     "@hyperjump/uri" "^1.2.0"
     content-type "^1.0.4"
-    fastest-stable-stringify "^2.0.2"
+    json-stringify-deterministic "^1.0.12"
     just-curry-it "^5.3.0"
-    undici "^5.19.1"
     uuid "^9.0.0"
 
 "@hyperjump/pact@^1.2.0":
@@ -5799,7 +5802,7 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@^1.0.4, content-type@~1.0.4:
+content-type@^1.0.4, content-type@^1.0.5, content-type@~1.0.4:
   version "1.0.5"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -6988,11 +6991,6 @@ fast-url-parser@1.1.3:
   integrity sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==
   dependencies:
     punycode "^1.3.2"
-
-fastest-stable-stringify@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz"
-  integrity sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==
 
 fastq@^1.6.0:
   version "1.16.0"
@@ -8661,6 +8659,11 @@ json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
+json-stringify-deterministic@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/json-stringify-deterministic/-/json-stringify-deterministic-1.0.12.tgz#aaa3f907466ed01e3afd77b898d0a2b3b132820a"
+  integrity sha512-q3PN0lbUdv0pmurkBNdJH3pfFvOTL/Zp0lquqpvcjfKzt6Y0j49EPHAmVHCAS4Ceq/Y+PejWTzyiVpoY71+D6g==
 
 json-stringify-safe@^5.0.1:
   version "5.0.1"
@@ -13329,7 +13332,7 @@ type-fest@^2.13.0, type-fest@^2.5.0:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
-type-is@~1.6.18:
+type-is@^1.6.18, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -13373,13 +13376,6 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-undici@^5.19.1:
-  version "5.28.2"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz"
-  integrity sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This package is used for testing schema validity, as well as to test that schema examples adhere to the schema itself.

- Switch to new BASIC output format
- Add required peer dependency