### PR TITLE
Allow empty context objects and treat omitted `"context"` properties as equivalent to empty values

### DIFF
--- a/schemas/program.schema.yaml
+++ b/schemas/program.schema.yaml
@@ -38,7 +38,11 @@ properties:
     description: |
       The context known to exist prior to the execution of the first
       instruction in the bytecode.
+
+      This field is **optional**. Omitting it is equivalent to specifying the
+      empty context value (`{}`).
     $ref: "schema:ethdebug/format/program/context"
+    default: {}
 
   instructions:
     type: array

--- a/schemas/program/context.schema.yaml
+++ b/schemas/program/context.schema.yaml
@@ -13,7 +13,6 @@ anyOf:
   - $ref: "schema:ethdebug/format/program/context/variables"
   - $ref: "schema:ethdebug/format/program/context/remark"
 
-minProperties: 1
 unevaluatedProperties: false
 
 examples:

--- a/schemas/program/instruction.schema.yaml
+++ b/schemas/program/instruction.schema.yaml
@@ -43,11 +43,14 @@ properties:
   context:
     description: |
       The context known to exist following the execution of this instruction.
+
+      This field is **optional**. Omitting it is equivalent to specifying the
+      empty context value (`{}`).
     $ref: "schema:ethdebug/format/program/context"
+    default: {}
 
 required:
   - offset
-  - context
 
 examples:
   - offset: 0


### PR DESCRIPTION
As per discussion [around here](https://matrix.to/#/!uDzRSTeqPjFVMZFtZp:matrix.org/$vMLDiSmjXFQvBkyuTCvMD1zg6hy1kvMk4aDUTd5RL9k?via=matrix.org&via=ethereum.org&via=ekpyron.org) in Matrix.chat