### PR TITLE
Define explicit `title` properties for all mdx spec files

### DIFF
--- a/packages/web/spec/data/hex.mdx
+++ b/packages/web/spec/data/hex.mdx
@@ -1,4 +1,6 @@
 ---
+title: Hexadecimal strings | ethdebug/format/data
+sidebar_label: Hexadecimal strings
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/data/overview.mdx
+++ b/packages/web/spec/data/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Overview | ethdebug/format/data
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/data/unsigned.mdx
+++ b/packages/web/spec/data/unsigned.mdx
@@ -1,4 +1,6 @@
 ---
+title: Unsigned integers | ethdebug/format/data
+sidebar_label: Unsigned integers
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/data/value.mdx
+++ b/packages/web/spec/data/value.mdx
@@ -1,4 +1,6 @@
 ---
+title: Non-negative numeric values | ethdebug/format/data
+sidebar_label: Non-negative numeric values
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/info/info.mdx
+++ b/packages/web/spec/info/info.mdx
@@ -1,4 +1,6 @@
 ---
+title: Schema | ethdebug/format/info
+sidebar_label: Schema
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/info/overview.mdx
+++ b/packages/web/spec/info/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Overview | ethdebug/format/info
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/info/resources.mdx
+++ b/packages/web/spec/info/resources.mdx
@@ -1,4 +1,6 @@
 ---
+title: Resources lookup schema | ethdebug/format/info
+sidebar_label: Resources lookup schema
 sidebar_position: 5
 ---
 

--- a/packages/web/spec/materials/compilation.mdx
+++ b/packages/web/spec/materials/compilation.mdx
@@ -1,4 +1,6 @@
 ---
+title: Compilation schema | ethdebug/format/materials
+sidebar_label: Compilation schema
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/materials/id.mdx
+++ b/packages/web/spec/materials/id.mdx
@@ -1,4 +1,6 @@
 ---
+title: Identifiers and references | ethdebug/format/materials
+sidebar_label: Identifiers and references
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/materials/overview.mdx
+++ b/packages/web/spec/materials/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Overview | ethdebug/format/materials
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/materials/source-range.mdx
+++ b/packages/web/spec/materials/source-range.mdx
@@ -1,4 +1,6 @@
 ---
+title: Source range schema | ethdebug/format/materials
+sidebar_label: Source range schema
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/materials/source.mdx
+++ b/packages/web/spec/materials/source.mdx
@@ -1,4 +1,6 @@
 ---
+title: Source schema | ethdebug/format/materials
+sidebar_label: Source schema
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/overview.mdx
+++ b/packages/web/spec/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Specification overview | ethdebug/format
+sidebar_label: Specification overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/pointer/collection/collection.mdx
+++ b/packages/web/spec/pointer/collection/collection.mdx
@@ -1,4 +1,6 @@
 ---
+title: Collection schema | ethdebug/format/pointer » Collections
+sidebar_label: Collection schema
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/pointer/collection/conditional.mdx
+++ b/packages/web/spec/pointer/collection/conditional.mdx
@@ -1,4 +1,6 @@
 ---
+title: Conditional | ethdebug/format/pointer » Collections
+sidebar_label: Conditional
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/pointer/collection/group.mdx
+++ b/packages/web/spec/pointer/collection/group.mdx
@@ -1,4 +1,6 @@
 ---
+title: Group | ethdebug/format/pointer » Collections
+sidebar_label: Group
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/pointer/collection/list.mdx
+++ b/packages/web/spec/pointer/collection/list.mdx
@@ -1,4 +1,6 @@
 ---
+title: List | ethdebug/format/pointer » Collections
+sidebar_label: List
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/pointer/collection/scope.mdx
+++ b/packages/web/spec/pointer/collection/scope.mdx
@@ -1,4 +1,6 @@
 ---
+title: Scope | ethdebug/format/pointer » Collections
+sidebar_label: Scope
 sidebar_position: 5
 ---
 

--- a/packages/web/spec/pointer/concepts.mdx
+++ b/packages/web/spec/pointer/concepts.mdx
@@ -1,4 +1,6 @@
 ---
+title: Key concepts | ethdebug/format/pointer
+sidebar_label: Key concepts
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/pointer/expression.mdx
+++ b/packages/web/spec/pointer/expression.mdx
@@ -1,4 +1,6 @@
 ---
+title: Expression syntax | ethdebug/format/pointer
+sidebar_label: Expression syntax
 sidebar_position: 6
 ---
 

--- a/packages/web/spec/pointer/overview.mdx
+++ b/packages/web/spec/pointer/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Overview | ethdebug/format/pointer
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/pointer/pointer.mdx
+++ b/packages/web/spec/pointer/pointer.mdx
@@ -1,4 +1,6 @@
 ---
+title: Schema | ethdebug/format/pointer
+sidebar_label: Schema
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/pointer/region/base.mdx
+++ b/packages/web/spec/pointer/region/base.mdx
@@ -1,4 +1,6 @@
 ---
+title: Base region schema | ethdebug/format/pointer » Regions
+sidebar_label: Base region schema
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/pointer/region/location/calldata.mdx
+++ b/packages/web/spec/pointer/region/location/calldata.mdx
@@ -1,4 +1,6 @@
 ---
+title: calldata | ethdebug/format/pointer » Regions » Locations
+sidebar_label: calldata
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/pointer/region/location/code.mdx
+++ b/packages/web/spec/pointer/region/location/code.mdx
@@ -1,4 +1,6 @@
 ---
+title: code | ethdebug/format/pointer » Regions » Locations
+sidebar_label: code
 sidebar_position: 7
 ---
 

--- a/packages/web/spec/pointer/region/location/memory.mdx
+++ b/packages/web/spec/pointer/region/location/memory.mdx
@@ -1,4 +1,6 @@
 ---
+title: memory | ethdebug/format/pointer » Regions » Locations
+sidebar_label: memory
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/pointer/region/location/returndata.mdx
+++ b/packages/web/spec/pointer/region/location/returndata.mdx
@@ -1,4 +1,6 @@
 ---
+title: returndata | ethdebug/format/pointer » Regions » Locations
+sidebar_label: returndata
 sidebar_position: 5
 ---
 

--- a/packages/web/spec/pointer/region/location/stack.mdx
+++ b/packages/web/spec/pointer/region/location/stack.mdx
@@ -1,4 +1,6 @@
 ---
+title: stack | ethdebug/format/pointer » Regions » Locations
+sidebar_label: stack
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/pointer/region/location/storage.mdx
+++ b/packages/web/spec/pointer/region/location/storage.mdx
@@ -1,4 +1,6 @@
 ---
+title: storage | ethdebug/format/pointer » Regions » Locations
+sidebar_label: storage
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/pointer/region/location/transient.mdx
+++ b/packages/web/spec/pointer/region/location/transient.mdx
@@ -1,4 +1,6 @@
 ---
+title: transient | ethdebug/format/pointer » Regions » Locations
+sidebar_label: transient
 sidebar_position: 6
 ---
 

--- a/packages/web/spec/pointer/region/region.mdx
+++ b/packages/web/spec/pointer/region/region.mdx
@@ -1,4 +1,6 @@
 ---
+title: Region schema | ethdebug/format/pointer » Regions
+sidebar_label: Region schema
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/pointer/region/scheme/segment.mdx
+++ b/packages/web/spec/pointer/region/scheme/segment.mdx
@@ -1,4 +1,6 @@
 ---
+title: segment | ethdebug/format/pointer » Regions » Addressing schemes
+sidebar_label: segment
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/pointer/region/scheme/slice.mdx
+++ b/packages/web/spec/pointer/region/scheme/slice.mdx
@@ -1,4 +1,6 @@
 ---
+title: slice | ethdebug/format/pointer » Regions » Addressing schemes
+sidebar_label: slice
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/pointer/template.mdx
+++ b/packages/web/spec/pointer/template.mdx
@@ -1,4 +1,6 @@
 ---
+title: Pointer templates | ethdebug/format/pointer
+sidebar_label: Pointer templates
 sidebar_position: 7
 ---
 

--- a/packages/web/spec/program/concepts.mdx
+++ b/packages/web/spec/program/concepts.mdx
@@ -1,4 +1,6 @@
 ---
+title: Key concepts | ethdebug/format/program
+sidebar_label: Key concepts
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/program/context/code.mdx
+++ b/packages/web/spec/program/context/code.mdx
@@ -1,4 +1,6 @@
 ---
+title: Code contexts | ethdebug/format/program » Contexts
+sidebar_label: Code contexts
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/program/context/context.mdx
+++ b/packages/web/spec/program/context/context.mdx
@@ -1,4 +1,6 @@
 ---
+title: Schema | ethdebug/format/program » Contexts
+sidebar_label: Schema
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/program/context/remark.mdx
+++ b/packages/web/spec/program/context/remark.mdx
@@ -1,4 +1,6 @@
 ---
+title: Human-readable annotations | ethdebug/format/program » Contexts
+sidebar_label: Human-readable annotations
 sidebar_position: 6
 ---
 

--- a/packages/web/spec/program/context/variables.mdx
+++ b/packages/web/spec/program/context/variables.mdx
@@ -1,4 +1,6 @@
 ---
+title: Variables contexts | ethdebug/format/program » Contexts
+sidebar_label: Variables contexts
 sidebar_position: 5
 ---
 

--- a/packages/web/spec/program/example.mdx
+++ b/packages/web/spec/program/example.mdx
@@ -1,4 +1,6 @@
 ---
+title: Example program | ethdebug/format/program
+sidebar_label: Example program
 sidebar_position: 3
 ---
 

--- a/packages/web/spec/program/instruction.mdx
+++ b/packages/web/spec/program/instruction.mdx
@@ -1,4 +1,6 @@
 ---
+title: Instruction schema | ethdebug/format/program
+sidebar_label: Instruction schema
 sidebar_position: 5
 ---
 

--- a/packages/web/spec/program/overview.mdx
+++ b/packages/web/spec/program/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Overview | ethdebug/format/program
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/program/program.mdx
+++ b/packages/web/spec/program/program.mdx
@@ -1,4 +1,6 @@
 ---
+title: Schema | ethdebug/format/program
+sidebar_label: Schema
 sidebar_position: 4
 ---
 

--- a/packages/web/spec/type/base.mdx
+++ b/packages/web/spec/type/base.mdx
@@ -1,4 +1,6 @@
 ---
+title: Base schema | ethdebug/format/type
+sidebar_label: Base schema
 sidebar_position: 6
 ---
 

--- a/packages/web/spec/type/complex/alias.mdx
+++ b/packages/web/spec/type/complex/alias.mdx
@@ -1,4 +1,6 @@
 ---
+title: alias | ethdebug/format/type » Complex types
+sidebar_label: alias
 sidebar_position: 1
 description: Alias types schema
 ---

--- a/packages/web/spec/type/complex/array.mdx
+++ b/packages/web/spec/type/complex/array.mdx
@@ -1,4 +1,6 @@
 ---
+title: array | ethdebug/format/type » Complex types
+sidebar_label: array
 sidebar_position: 3
 description: Array types schema
 ---

--- a/packages/web/spec/type/complex/function.mdx
+++ b/packages/web/spec/type/complex/function.mdx
@@ -1,4 +1,6 @@
 ---
+title: function | ethdebug/format/type » Complex types
+sidebar_label: function
 sidebar_position: 6
 description: Function types schema
 ---

--- a/packages/web/spec/type/complex/mapping.mdx
+++ b/packages/web/spec/type/complex/mapping.mdx
@@ -1,4 +1,6 @@
 ---
+title: mapping | ethdebug/format/type » Complex types
+sidebar_label: mapping
 sidebar_position: 4
 description: Mapping types schema
 ---

--- a/packages/web/spec/type/complex/struct.mdx
+++ b/packages/web/spec/type/complex/struct.mdx
@@ -1,4 +1,6 @@
 ---
+title: struct | ethdebug/format/type » Complex types
+sidebar_label: struct
 sidebar_position: 5
 description: Struct types schema
 ---

--- a/packages/web/spec/type/complex/tuple.mdx
+++ b/packages/web/spec/type/complex/tuple.mdx
@@ -1,4 +1,6 @@
 ---
+title: tuple | ethdebug/format/type » Complex types
+sidebar_label: tuple
 sidebar_position: 2
 description: Tuple types schema
 ---

--- a/packages/web/spec/type/concepts.mdx
+++ b/packages/web/spec/type/concepts.mdx
@@ -1,4 +1,6 @@
 ---
+title: Key concepts | ethdebug/format/type
+sidebar_label: Key concepts
 sidebar_position: 2
 ---
 

--- a/packages/web/spec/type/elementary/address.mdx
+++ b/packages/web/spec/type/elementary/address.mdx
@@ -1,4 +1,6 @@
 ---
+title: address | ethdebug/format/type » Elementary types
+sidebar_label: address
 sidebar_position: 8
 description: Address types schema
 ---

--- a/packages/web/spec/type/elementary/bool.mdx
+++ b/packages/web/spec/type/elementary/bool.mdx
@@ -1,4 +1,6 @@
 ---
+title: bool | ethdebug/format/type » Elementary types
+sidebar_label: bool
 sidebar_position: 5
 description: Boolean type schema
 ---

--- a/packages/web/spec/type/elementary/bytes.mdx
+++ b/packages/web/spec/type/elementary/bytes.mdx
@@ -1,4 +1,6 @@
 ---
+title: bytes | ethdebug/format/type » Elementary types
+sidebar_label: bytes
 sidebar_position: 6
 description: Bytes string types schema
 ---

--- a/packages/web/spec/type/elementary/contract.mdx
+++ b/packages/web/spec/type/elementary/contract.mdx
@@ -1,4 +1,6 @@
 ---
+title: contract | ethdebug/format/type » Elementary types
+sidebar_label: contract
 sidebar_position: 9
 description: Contract types schema
 ---

--- a/packages/web/spec/type/elementary/enum.mdx
+++ b/packages/web/spec/type/elementary/enum.mdx
@@ -1,4 +1,6 @@
 ---
+title: enum | ethdebug/format/type » Elementary types
+sidebar_label: enum
 sidebar_position: 10
 description: Enumerated values types schema
 ---

--- a/packages/web/spec/type/elementary/fixed.mdx
+++ b/packages/web/spec/type/elementary/fixed.mdx
@@ -1,4 +1,6 @@
 ---
+title: fixed | ethdebug/format/type » Elementary types
+sidebar_label: fixed
 sidebar_position: 4
 description: Signed decimal fixed point types schema
 ---

--- a/packages/web/spec/type/elementary/int.mdx
+++ b/packages/web/spec/type/elementary/int.mdx
@@ -1,4 +1,6 @@
 ---
+title: int | ethdebug/format/type » Elementary types
+sidebar_label: int
 sidebar_position: 2
 description: Signed integer types schema
 ---

--- a/packages/web/spec/type/elementary/string.mdx
+++ b/packages/web/spec/type/elementary/string.mdx
@@ -1,4 +1,6 @@
 ---
+title: string | ethdebug/format/type » Elementary types
+sidebar_label: string
 sidebar_position: 7
 description: String types schema
 ---

--- a/packages/web/spec/type/elementary/ufixed.mdx
+++ b/packages/web/spec/type/elementary/ufixed.mdx
@@ -1,4 +1,6 @@
 ---
+title: ufixed | ethdebug/format/type » Elementary types
+sidebar_label: ufixed
 sidebar_position: 3
 description: Unsigned decimal fixed point types schema
 ---

--- a/packages/web/spec/type/elementary/uint.mdx
+++ b/packages/web/spec/type/elementary/uint.mdx
@@ -1,4 +1,6 @@
 ---
+title: uint | ethdebug/format/type » Elementary types
+sidebar_label: uint
 sidebar_position: 1
 description: Unsigned integer types schema
 ---

--- a/packages/web/spec/type/overview.mdx
+++ b/packages/web/spec/type/overview.mdx
@@ -1,4 +1,6 @@
 ---
+title: Overview | ethdebug/format/type
+sidebar_label: Overview
 sidebar_position: 1
 ---
 

--- a/packages/web/spec/type/type.mdx
+++ b/packages/web/spec/type/type.mdx
@@ -1,4 +1,6 @@
 ---
+title: Schema | ethdebug/format/type
+sidebar_label: Schema
 sidebar_position: 3
 ---
 


### PR DESCRIPTION
- Add breadcrumbs to each
- Ensure sidebar/in-page rendering still uses the short-form without the breadcrumbs by using the `sidebar_label` property