### PR TITLE
Use Github Pages for PR previews

### DIFF
--- a/.github/workflows/deploy-pr-previews.yml
+++ b/.github/workflows/deploy-pr-previews.yml
@@ -1,0 +1,36 @@
+name: Deploy PR preview
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build website
+        run: BASE_URL='/format/pr-preview/pr-${{ github.event.number }}/' yarn build
+        working-directory: ./packages/web
+
+      - name: Deploy to GitHub Pages
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          source-dir: ./packages/web/build
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,13 +23,16 @@ jobs:
         working-directory: ./packages/web
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-          publish_dir: ./packages/web/build
-
+          token: ${{ secrets.GITHUB_TOKEN }}
+          folder: ./packages/web/build
+          branch: gh-pages
           # default deployer
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          git-config-name: 'github-actions[bot]'
+          git-config-email: 'github-actions[bot]@users.noreply.github.com'
+          # don't break preview deployments
+          clean-exclude: pr-preview
+          force: false
+
 


### PR DESCRIPTION
This PR uses [this action](https://github.com/marketplace/actions/deploy-pr-preview) for doing preview deployments.

To make it easier to respect that repo's stated "gotchas", this PR also switches to [this action](https://github.com/JamesIves/github-pages-deploy-action) for the main deployment.