### PR TITLE
Avoid conditionals for defining tagged unions.

### DIFF
--- a/schemas/materials/compilation.schema.yaml
+++ b/schemas/materials/compilation.schema.yaml
@@ -63,7 +63,7 @@ properties:
           have access to the full representation by some other means)
 
     allOf:
-      - true
+      - {}
 
   sources:
     type: array

--- a/schemas/pointer/collection.schema.yaml
+++ b/schemas/pointer/collection.schema.yaml
@@ -6,35 +6,9 @@ description: |
   A representation of a collection of pointers to data in the EVM
 type: object
 
-allOf:
-  - oneOf:
-      - required: [group]
-      - required: [list]
-      - required: [if]
-      - required: [define]
-      - required: [template]
-
-  - if:
-      required: [group]
-    then:
-      $ref: "schema:ethdebug/format/pointer/collection/group"
-
-  - if:
-      required: [list]
-    then:
-      $ref: "schema:ethdebug/format/pointer/collection/list"
-
-  - if:
-      required: [if]
-    then:
-      $ref: "schema:ethdebug/format/pointer/collection/conditional"
-
-  - if:
-      required: [define]
-    then:
-      $ref: "schema:ethdebug/format/pointer/collection/scope"
-
-  - if:
-      required: [template]
-    then:
-      $ref: "schema:ethdebug/format/pointer/collection/reference"
+oneOf:
+  - $ref: "schema:ethdebug/format/pointer/collection/group"
+  - $ref: "schema:ethdebug/format/pointer/collection/list"
+  - $ref: "schema:ethdebug/format/pointer/collection/conditional"
+  - $ref: "schema:ethdebug/format/pointer/collection/scope"
+  - $ref: "schema:ethdebug/format/pointer/collection/reference"

--- a/schemas/pointer/region.schema.yaml
+++ b/schemas/pointer/region.schema.yaml
@@ -6,74 +6,14 @@ description: |
   A representation of a region of data in the EVM
 type: object
 
-properties:
-  location:
-    $ref: "#/$defs/Location"
-
-
-allOf:
-  - if:
-      properties:
-        location:
-          const: stack
-
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/stack"
-
-  - if:
-      properties:
-        location:
-          const: memory
-
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/memory"
-
-  - if:
-      properties:
-        location:
-          const: storage
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/storage"
-
-  - if:
-      properties:
-        location:
-          const: calldata
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/calldata"
-
-  - if:
-      properties:
-        location:
-          const: returndata
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/returndata"
-
-  - if:
-      properties:
-        location:
-          const: transient
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/transient"
-
-  - if:
-      properties:
-        location:
-          const: code
-    then:
-      $ref: "schema:ethdebug/format/pointer/region/code"
-
-$defs:
-  Location:
-    type: string
-    enum:
-      - stack
-      - memory
-      - storage
-      - calldata
-      - returndata
-      - transient
-      - code
+oneOf:
+  - $ref: "schema:ethdebug/format/pointer/region/stack"
+  - $ref: "schema:ethdebug/format/pointer/region/memory"
+  - $ref: "schema:ethdebug/format/pointer/region/storage"
+  - $ref: "schema:ethdebug/format/pointer/region/calldata"
+  - $ref: "schema:ethdebug/format/pointer/region/returndata"
+  - $ref: "schema:ethdebug/format/pointer/region/transient"
+  - $ref: "schema:ethdebug/format/pointer/region/code"
 
 unevaluatedProperties: false
 

--- a/schemas/pointer/region/base.schema.yaml
+++ b/schemas/pointer/region/base.schema.yaml
@@ -11,10 +11,22 @@ properties:
     $ref: "schema:ethdebug/format/pointer/identifier"
 
   location:
-    type: string
+    $ref: "#/$defs/Location"
 
 required:
   - location
+
+$defs:
+  Location:
+    type: string
+    enum:
+      - stack
+      - memory
+      - storage
+      - calldata
+      - returndata
+      - transient
+      - code
 
 examples:
   - name: "array-item"


### PR DESCRIPTION
# Avoid conditionals for defining tagged unions.

This PR simplifies the schema structure of the region and collection listings by replacing a large `if`-based conditional block with a more concise `oneOf` declaration. The resulting schemas should be logically equivalent but offer better compatibility with tooling.

## Benefits of using `oneOf`:

* Easer to read
* **Consistency**: This change brings the pointer schemas in line with the existing expression schema, which already uses `oneOf`.
* **Improved tool support**: `oneOf` has been around longer and is better supported across the ecosystem. Validation and code generation libraries (e.g., Python's datamodel-code-generator) have built-in support for `oneOf`, but haven't yet caught up with `if`-blocks.
* **Better compatibility with statically typed languages**: Unlike `if/then`, which often requires complex conditional typing, `oneOf` maps more directly to union types or class hierarchies.

## Background

In our case, we use [datamodel-code-generator](https://koxudaxi.github.io/datamodel-code-generator/) to generate Python validators from the JSON Schema. This tool supports `oneOf` but does not yet support `if/then`, making the refactor necessary for proper code generation.

Additionally, this PR changes an instance of `allOf: true` to `allOf: {}`. These are logically equivalent, but the former is a newer convention not yet supported by all tools, including `datamodel-code-generator`.

## Additional considerations

The grouping and expression schemas currently discriminate between their variants based on the presence of specific properties. In contrast, the region schema uses the value of the `location` field to distinguish its variants. This inconsistency might be worth addressing.

