### PR TITLE
docs: add invoke.mdx prose intro and cross-link spec pages

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing.mdx
+++ b/packages/web/docs/core-schemas/programs/tracing.mdx
@@ -351,6 +351,8 @@ function decodeValue(bytes: Data, type: Type): string {
 
 ## Learn more
 
+- [Function context schemas](/spec/program/context/function) for the
+  invoke, return, and revert specifications
 - [Instructions documentation](./instructions) for understanding instruction
   records
 - [Variables documentation](./variables) for variable structure and lifetime

--- a/packages/web/spec/program/context/function/function.mdx
+++ b/packages/web/spec/program/context/function/function.mdx
@@ -11,7 +11,11 @@ identity fields for the function being called. All fields are
 optional, allowing compilers to provide as much or as little
 detail as available — from a fully named function with source
 location and type, down to an empty object for an anonymous
-indirect call.
+indirect call. See
+[invoke](/spec/program/context/function/invoke),
+[return](/spec/program/context/function/return), and
+[revert](/spec/program/context/function/revert) for the
+individual context schemas.
 
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/program/context/function" }}

--- a/packages/web/spec/program/context/function/invoke.mdx
+++ b/packages/web/spec/program/context/function/invoke.mdx
@@ -6,6 +6,19 @@ import SchemaViewer from "@site/src/components/SchemaViewer";
 
 # Invocation contexts
 
+An invoke context marks an instruction that enters a function.
+The schema distinguishes three kinds of invocation — internal
+calls (via JUMP), external message calls (CALL/DELEGATECALL/
+STATICCALL), and contract creations (CREATE/CREATE2) — each
+with fields appropriate to the call mechanism.
+
+All variants extend the [function identity](/spec/program/context/function)
+schema and may include pointers to the call target, arguments,
+gas, value, and input data as applicable. See
+[Tracing execution](/docs/core-schemas/programs/tracing) for
+worked examples showing how debuggers use invoke and return
+contexts to reconstruct call stacks.
+
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/program/context/function/invoke" }}
 />

--- a/packages/web/spec/program/context/function/return.mdx
+++ b/packages/web/spec/program/context/function/return.mdx
@@ -9,7 +9,8 @@ import SchemaViewer from "@site/src/components/SchemaViewer";
 A return context marks an instruction associated with a successful
 function return. It extends the function identity schema with a
 pointer to the return data and, for external calls, the success
-status.
+status. It extends the
+[function identity](/spec/program/context/function) schema.
 
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/program/context/function/return" }}

--- a/packages/web/spec/program/context/function/revert.mdx
+++ b/packages/web/spec/program/context/function/revert.mdx
@@ -9,7 +9,8 @@ import SchemaViewer from "@site/src/components/SchemaViewer";
 A revert context marks an instruction associated with a function
 revert. It extends the function identity schema with an optional
 pointer to revert reason data and/or a numeric panic code for
-built-in assertion failures.
+built-in assertion failures. It extends the
+[function identity](/spec/program/context/function) schema.
 
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/program/context/function/revert" }}


### PR DESCRIPTION
## Summary

- Add descriptive introduction to the invocation contexts spec page (`invoke.mdx`), matching the pattern of `function.mdx`, `return.mdx`, and `revert.mdx`
- Add cross-links between function context spec pages and the tracing documentation