### PR TITLE
docs: expand return and revert spec pages

### DIFF
--- a/packages/web/spec/program/context/function/return.mdx
+++ b/packages/web/spec/program/context/function/return.mdx
@@ -7,11 +7,53 @@ import SchemaViewer from "@site/src/components/SchemaViewer";
 # Return contexts
 
 A return context marks an instruction associated with a successful
-function return. It extends the function identity schema with a
-pointer to the return data and, for external calls, the success
-status. It extends the
-[function identity](/spec/program/context/function) schema.
+function return. It extends the
+[function identity](/spec/program/context/function) schema with
+a pointer to the return data and, for external calls, the
+success status.
 
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/program/context/function/return" }}
 />
+
+## Return data
+
+The `data` field is required and contains a pointer to the value
+being returned. For internal calls this typically points to a
+stack location; for external calls it points into the
+`returndata` buffer.
+
+## Internal return
+
+An internal return marks the JUMP instruction that transfers
+control back to the caller within the same contract. The
+function leaves its return value on the stack, so `data` points
+to the relevant stack slot.
+
+Internal returns do not use the `success` field—internal calls
+either return normally or revert, with no separate success flag.
+
+## External call return
+
+An external call return marks an instruction after a CALL,
+DELEGATECALL, or STATICCALL that completed successfully. The
+EVM places a success flag on the stack (1 for success, 0 for
+failure), and the callee's output is accessible via the
+returndata buffer.
+
+The `success` field is specific to external call returns. It
+contains a pointer to the boolean success value on the stack,
+letting the debugger distinguish successful returns from
+reverts at the EVM level.
+
+## Field optionality
+
+The `data` pointer is always required—every return context must
+indicate where the return value can be found. The `success`
+field is optional and only meaningful for external calls.
+
+Function identity fields (`identifier`, `declaration`, `type`)
+are all optional. A compiler may omit them when it cannot
+attribute the return to a specific named function, for instance
+when returning from a fallback function or an anonymous code
+path.

--- a/packages/web/spec/program/context/function/revert.mdx
+++ b/packages/web/spec/program/context/function/revert.mdx
@@ -7,11 +7,52 @@ import SchemaViewer from "@site/src/components/SchemaViewer";
 # Revert contexts
 
 A revert context marks an instruction associated with a function
-revert. It extends the function identity schema with an optional
-pointer to revert reason data and/or a numeric panic code for
-built-in assertion failures. It extends the
-[function identity](/spec/program/context/function) schema.
+revert. It extends the
+[function identity](/spec/program/context/function) schema with
+an optional pointer to revert reason data and/or a numeric
+panic code for built-in assertion failures.
 
 <SchemaViewer
   schema={{ id: "schema:ethdebug/format/program/context/function/revert" }}
 />
+
+## Reason-based revert
+
+The `reason` field contains a pointer to the revert reason data
+in memory or, for external calls, in the returndata buffer.
+This typically holds an ABI-encoded error: a `require()` failure
+produces an `Error(string)` payload, while custom errors produce
+their own ABI-encoded selector and arguments.
+
+For an internal revert, `reason` points into memory where the
+compiler has written the encoded error. For an external call
+that reverted, `reason` points into the `returndata` buffer
+containing the callee's revert output.
+
+## Panic codes
+
+The `panic` field carries a numeric code for built-in assertion
+failures that the compiler inserts automatically. These do not
+originate from explicit `revert` or `require` statements—they
+guard against conditions like arithmetic overflow or
+out-of-bounds array access.
+
+Languages define their own panic code conventions. For example,
+Solidity uses `0x01` for failed `assert()`, `0x11` for
+arithmetic overflow, and `0x32` for out-of-bounds indexing.
+
+A revert context may include `panic` alone (when no reason
+pointer is needed), `reason` alone, or both.
+
+## Field optionality
+
+Both `reason` and `panic` are optional. A revert context is
+valid with either, both, or neither—a bare `revert: {}` is
+permitted when the compiler knows a revert occurred but has no
+further detail.
+
+Function identity fields (`identifier`, `declaration`, `type`)
+are also optional. A compiler may omit them when the revert
+cannot be attributed to a specific function, such as a
+top-level `require` guard or an unattributed external call
+failure.


### PR DESCRIPTION
## Summary

- Expands `return.mdx` from 16 to ~50 lines with subsections for internal return, external call return, the `success` field, and field optionality
- Expands `revert.mdx` from 16 to ~50 lines with subsections for reason-based reverts, panic codes, and field optionality
- Both pages now match the depth and structure of `invoke.mdx`