### PR TITLE
bugc-react: surface invoke/return/revert contexts in BytecodeView

### DIFF
--- a/packages/bugc-react/src/components/BytecodeView.css
+++ b/packages/bugc-react/src/components/BytecodeView.css
@@ -113,3 +113,82 @@
 .opcode-line .immediates {
   color: var(--bugc-syntax-number);
 }
+
+/* Context badges for invoke/return/revert */
+.context-badge {
+  cursor: pointer;
+  padding: 0.0625rem 0.25rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  user-select: none;
+  display: inline-block;
+  min-width: 1.2rem;
+  text-align: center;
+  transition: all 0.15s ease;
+}
+
+.context-badge-invoke {
+  color: var(--bugc-accent-blue);
+  background-color: var(--bugc-accent-blue-bg);
+}
+
+.context-badge-invoke:hover {
+  background-color: var(--bugc-accent-blue);
+  color: var(--bugc-bg-primary);
+}
+
+.context-badge-return {
+  color: var(--bugc-accent-green);
+  background-color: var(--bugc-accent-green-bg);
+}
+
+.context-badge-return:hover {
+  background-color: var(--bugc-accent-green);
+  color: var(--bugc-bg-primary);
+}
+
+.context-badge-revert {
+  color: var(--bugc-accent-red);
+  background-color: rgba(207, 34, 46, 0.1);
+}
+
+.context-badge-revert:hover {
+  background-color: var(--bugc-accent-red);
+  color: var(--bugc-bg-primary);
+}
+
+/* Inline context labels */
+.context-label {
+  font-size: 0.75rem;
+  font-style: italic;
+  margin-left: 0.5rem;
+}
+
+.context-label-invoke {
+  color: var(--bugc-accent-blue);
+}
+
+.context-label-return {
+  color: var(--bugc-accent-green);
+}
+
+.context-label-revert {
+  color: var(--bugc-accent-red);
+}
+
+/* Highlight rows with call contexts */
+.opcode-line.context-invoke {
+  border-left: 2px solid var(--bugc-accent-blue);
+  padding-left: calc(0.5rem - 2px);
+}
+
+.opcode-line.context-return {
+  border-left: 2px solid var(--bugc-accent-green);
+  padding-left: calc(0.5rem - 2px);
+}
+
+.opcode-line.context-revert {
+  border-left: 2px solid var(--bugc-accent-red);
+  padding-left: calc(0.5rem - 2px);
+}

--- a/packages/bugc-react/src/components/BytecodeView.tsx
+++ b/packages/bugc-react/src/components/BytecodeView.tsx
@@ -5,9 +5,27 @@
 import React from "react";
 import type { Evm } from "@ethdebug/bugc";
 import type { BytecodeOutput, SourceRange } from "#types";
-import { extractSourceRange } from "#utils/debugUtils";
+import {
+  extractSourceRange,
+  classifyContext,
+  summarizeContext,
+  type ContextKind,
+} from "#utils/debugUtils";
 import { useEthdebugTooltip } from "#hooks/useEthdebugTooltip";
 import { EthdebugTooltip } from "./EthdebugTooltip.js";
+
+function contextBadgeLabel(kind: ContextKind): string {
+  switch (kind) {
+    case "invoke":
+      return "\u279c"; // arrow right
+    case "return":
+      return "\u21b5"; // return arrow
+    case "revert":
+      return "\u2717"; // x mark
+    default:
+      return "\u2139"; // info
+  }
+}
 
 /**
  * Props for BytecodeView component.
@@ -47,12 +65,35 @@ function InstructionsView({
     onOpcodeHover?.([]);
   };
 
+  const formatTooltipContent = (instruction: Evm.Instruction): string => {
+    const ctx = instruction.debug?.context;
+    if (!ctx) return "";
+
+    const summary = summarizeContext(ctx);
+    const lines: string[] = [];
+
+    if (
+      summary.kind === "invoke" ||
+      summary.kind === "return" ||
+      summary.kind === "revert"
+    ) {
+      lines.push(summary.label);
+      if (summary.details) {
+        lines.push(`  (${summary.details})`);
+      }
+      lines.push("");
+    }
+
+    lines.push(JSON.stringify(ctx, null, 2));
+    return lines.join("\n");
+  };
+
   const handleDebugIconMouseEnter = (
     e: React.MouseEvent<HTMLSpanElement>,
     instruction: Evm.Instruction,
   ) => {
     if (instruction.debug?.context) {
-      showTooltip(e, JSON.stringify(instruction.debug.context, null, 2));
+      showTooltip(e, formatTooltipContent(instruction));
     }
   };
 
@@ -61,7 +102,7 @@ function InstructionsView({
     instruction: Evm.Instruction,
   ) => {
     if (instruction.debug?.context) {
-      pinTooltip(e, JSON.stringify(instruction.debug.context, null, 2));
+      pinTooltip(e, formatTooltipContent(instruction));
     }
   };
 
@@ -73,22 +114,43 @@ function InstructionsView({
 
         const sourceRanges = extractSourceRange(instruction.debug?.context);
         const hasDebugInfo = !!instruction.debug?.context;
+        const kind: ContextKind = hasDebugInfo
+          ? classifyContext(instruction.debug?.context)
+          : "other";
+        const isCallContext =
+          kind === "invoke" || kind === "return" || kind === "revert";
 
         return (
           <div
             key={idx}
-            className={`opcode-line ${hasDebugInfo ? "has-debug-info" : ""}`}
+            className={[
+              "opcode-line",
+              hasDebugInfo ? "has-debug-info" : "",
+              isCallContext ? `context-${kind}` : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
             onMouseEnter={() => handleOpcodeMouseEnter(sourceRanges)}
             onMouseLeave={handleOpcodeMouseLeave}
           >
-            {hasDebugInfo ? (
+            {isCallContext ? (
+              <span
+                className={`context-badge context-badge-${kind}`}
+                onMouseEnter={(e) => handleDebugIconMouseEnter(e, instruction)}
+                onMouseLeave={hideTooltip}
+                onClick={(e) => handleDebugIconClick(e, instruction)}
+                title={summarizeContext(instruction.debug?.context).label}
+              >
+                {contextBadgeLabel(kind)}
+              </span>
+            ) : hasDebugInfo ? (
               <span
                 className="debug-info-icon"
                 onMouseEnter={(e) => handleDebugIconMouseEnter(e, instruction)}
                 onMouseLeave={hideTooltip}
                 onClick={(e) => handleDebugIconClick(e, instruction)}
               >
-                ℹ
+                {"\u2139"}
               </span>
             ) : (
               <span className="debug-info-spacer"></span>
@@ -101,6 +163,11 @@ function InstructionsView({
                 {instruction.immediates
                   .map((b) => b.toString(16).padStart(2, "0"))
                   .join("")}
+              </span>
+            )}
+            {isCallContext && (
+              <span className={`context-label context-label-${kind}`}>
+                {summarizeContext(instruction.debug?.context).label}
               </span>
             )}
           </div>

--- a/packages/bugc-react/src/index.ts
+++ b/packages/bugc-react/src/index.ts
@@ -50,6 +50,10 @@ export {
   extractSourceRange,
   formatDebugContext,
   hasSourceRange,
+  classifyContext,
+  summarizeContext,
+  type ContextKind,
+  type ContextSummary,
   // IR debug utilities
   extractInstructionDebug,
   extractTerminatorDebug,

--- a/packages/bugc-react/src/utils/debugUtils.ts
+++ b/packages/bugc-react/src/utils/debugUtils.ts
@@ -93,3 +93,139 @@ export function formatDebugContext(context: unknown): string {
 export function hasSourceRange(context: unknown): boolean {
   return extractSourceRange(context).length > 0;
 }
+
+/**
+ * Kinds of function call contexts.
+ */
+export type ContextKind =
+  | "invoke"
+  | "return"
+  | "revert"
+  | "remark"
+  | "code"
+  | "other";
+
+/**
+ * Classify a debug context by its top-level discriminant.
+ */
+export function classifyContext(context: unknown): ContextKind {
+  if (!context || typeof context !== "object") {
+    return "other";
+  }
+
+  const ctx = context as Record<string, unknown>;
+
+  if ("invoke" in ctx) return "invoke";
+  if ("return" in ctx) return "return";
+  if ("revert" in ctx) return "revert";
+  if ("remark" in ctx) return "remark";
+  if ("code" in ctx) return "code";
+
+  // Check inside gather — a gather of contexts inherits
+  // the kind of its function-call child if present
+  if ("gather" in ctx && Array.isArray(ctx.gather)) {
+    for (const item of ctx.gather) {
+      const kind = classifyContext(item);
+      if (kind === "invoke" || kind === "return" || kind === "revert") {
+        return kind;
+      }
+    }
+  }
+
+  return "other";
+}
+
+/**
+ * Summary of a function call context for display.
+ */
+export interface ContextSummary {
+  kind: ContextKind;
+  label: string;
+  functionName?: string;
+  details?: string;
+}
+
+/**
+ * Extract a human-readable summary from a debug context.
+ */
+export function summarizeContext(context: unknown): ContextSummary {
+  const kind = classifyContext(context);
+  const ctx = context as Record<string, unknown>;
+
+  switch (kind) {
+    case "invoke": {
+      const invoke = findNestedField(ctx, "invoke") as
+        | Record<string, unknown>
+        | undefined;
+      const name = (invoke?.identifier as string) ?? "unknown";
+      const callType = invoke?.jump
+        ? "internal"
+        : invoke?.message
+          ? "external"
+          : invoke?.create
+            ? "create"
+            : "";
+      return {
+        kind,
+        label: `invoke ${name}`,
+        functionName: name,
+        details: callType ? `${callType} call` : undefined,
+      };
+    }
+
+    case "return": {
+      const ret = findNestedField(ctx, "return") as
+        | Record<string, unknown>
+        | undefined;
+      const name = (ret?.identifier as string) ?? "unknown";
+      return {
+        kind,
+        label: `return ${name}`,
+        functionName: name,
+      };
+    }
+
+    case "revert": {
+      const rev = findNestedField(ctx, "revert") as
+        | Record<string, unknown>
+        | undefined;
+      const name = (rev?.identifier as string) ?? "unknown";
+      const panic = rev?.panic as number | undefined;
+      return {
+        kind,
+        label: `revert ${name}`,
+        functionName: name,
+        details: panic !== undefined ? `panic(${panic})` : undefined,
+      };
+    }
+
+    case "remark":
+      return {
+        kind,
+        label: ctx.remark as string,
+      };
+
+    case "code":
+      return { kind, label: "source mapping" };
+
+    default:
+      return { kind, label: "debug info" };
+  }
+}
+
+/**
+ * Find a field by name, searching inside gather arrays.
+ */
+function findNestedField(ctx: Record<string, unknown>, field: string): unknown {
+  if (field in ctx) return ctx[field];
+
+  if ("gather" in ctx && Array.isArray(ctx.gather)) {
+    for (const item of ctx.gather) {
+      if (item && typeof item === "object" && field in item) {
+        return (item as Record<string, unknown>)[field];
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/packages/bugc-react/src/utils/index.ts
+++ b/packages/bugc-react/src/utils/index.ts
@@ -6,6 +6,10 @@ export {
   extractSourceRange,
   formatDebugContext,
   hasSourceRange,
+  classifyContext,
+  summarizeContext,
+  type ContextKind,
+  type ContextSummary,
 } from "./debugUtils.js";
 
 export {


### PR DESCRIPTION
## Summary

- Add context-aware rendering for function call debug contexts in the bytecode disassembly view
- Instructions with invoke/return/revert contexts show colored badges (arrow/return/x) and inline labels instead of the generic info icon
- Colored left borders on context rows make call boundaries visually scannable
- Tooltip shows structured summary header before raw JSON context
- New `classifyContext`/`summarizeContext` utilities exported from bugc-react for reuse