### PR TITLE
bugc: add declaration source ranges and param names to call contexts

### DIFF
--- a/packages/bugc/src/evmgen/call-contexts.test.ts
+++ b/packages/bugc/src/evmgen/call-contexts.test.ts
@@ -73,6 +73,15 @@ code {
     expect(invoke.jump).toBe(true);
     expect(invoke.identifier).toBe("add");
 
+    // Should have declaration source range
+    const decl = invoke.declaration as Record<string, unknown>;
+    expect(decl).toBeDefined();
+    expect(decl.source).toEqual({ id: "0" });
+    expect(decl.range).toBeDefined();
+    const range = decl.range as Record<string, unknown>;
+    expect(typeof range.offset).toBe("number");
+    expect(typeof range.length).toBe("number");
+
     // Should have target pointer
     const target = invoke.target as Record<string, unknown>;
     expect(target.pointer).toBeDefined();
@@ -85,11 +94,13 @@ code {
     expect(group).toHaveLength(2);
     // First arg (a) is deepest on stack
     expect(group[0]).toEqual({
+      name: "a",
       location: "stack",
       slot: 1,
     });
     // Second arg (b) is on top
     expect(group[1]).toEqual({
+      name: "b",
       location: "stack",
       slot: 0,
     });
@@ -112,6 +123,11 @@ code {
     const ret = ctx.return as Record<string, unknown>;
 
     expect(ret.identifier).toBe("add");
+
+    // Should have declaration source range
+    const retDecl = ret.declaration as Record<string, unknown>;
+    expect(retDecl).toBeDefined();
+    expect(retDecl.source).toEqual({ id: "0" });
 
     // Should have data pointer to return value at
     // TOS (stack slot 0)
@@ -350,6 +366,7 @@ code {
       // Single arg at stack slot 0
       expect(group).toHaveLength(1);
       expect(group[0]).toEqual({
+        name: "x",
         location: "stack",
         slot: 0,
       });

--- a/packages/bugc/src/evmgen/generation/block.ts
+++ b/packages/bugc/src/evmgen/generation/block.ts
@@ -29,6 +29,7 @@ export function generate<S extends Stack>(
   isFirstBlock: boolean = false,
   isUserFunction: boolean = false,
   func?: Ir.Function,
+  functions?: Map<string, Ir.Function>,
 ): Transition<S, Stack> {
   const { JUMPDEST } = operations;
 
@@ -74,9 +75,18 @@ export function generate<S extends Stack>(
           // executes: TOS is the return value (if any).
           // data pointer is required by the schema; for
           // void returns, slot 0 is still valid (empty).
+          const calledFunc = functions?.get(calledFunction);
+          const declaration =
+            calledFunc?.loc && calledFunc?.sourceId
+              ? {
+                  source: { id: calledFunc.sourceId },
+                  range: calledFunc.loc,
+                }
+              : undefined;
           const returnCtx: Format.Program.Context.Return = {
             return: {
               identifier: calledFunction,
+              ...(declaration ? { declaration } : {}),
               data: {
                 pointer: {
                   location: "stack" as const,
@@ -142,7 +152,9 @@ export function generate<S extends Stack>(
       // Process terminator
       // Handle call terminators specially (they cross function boundaries)
       if (block.terminator.kind === "call") {
-        result = result.then(generateCallTerminator(block.terminator));
+        result = result.then(
+          generateCallTerminator(block.terminator, functions),
+        );
       } else {
         result = result.then(
           generateTerminator(block.terminator, isLastBlock, isUserFunction),

--- a/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
+++ b/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
@@ -147,14 +147,17 @@ export function generateTerminator<S extends Stack>(
 }
 
 /**
- * Generate code for a call terminator - handled specially since it crosses function boundaries
+ * Generate code for a call terminator - handled specially
+ * since it crosses function boundaries
  */
 export function generateCallTerminator<S extends Stack>(
   term: Extract<Ir.Block.Terminator, { kind: "call" }>,
+  functions?: Map<string, Ir.Function>,
 ): Transition<S, Stack> {
   const funcName = term.function;
   const args = term.arguments;
   const cont = term.continuation;
+  const targetFunc = functions?.get(funcName);
 
   return ((state: State<S>): State<Stack> => {
     let currentState: State<Stack> = state as State<Stack>;
@@ -227,10 +230,21 @@ export function generateCallTerminator<S extends Stack>(
 
     // Build argument pointers: after the JUMP, the callee
     // sees args on the stack in order (first arg deepest).
+    const params = targetFunc?.parameters;
     const argPointers = args.map((_arg, i) => ({
+      ...(params?.[i]?.name ? { name: params[i].name } : {}),
       location: "stack" as const,
       slot: args.length - 1 - i,
     }));
+
+    // Build declaration source range if available
+    const declaration =
+      targetFunc?.loc && targetFunc?.sourceId
+        ? {
+            source: { id: targetFunc.sourceId },
+            range: targetFunc.loc,
+          }
+        : undefined;
 
     // Invoke context describes state after JUMP executes:
     // the callee has been entered with args on the stack.
@@ -240,8 +254,12 @@ export function generateCallTerminator<S extends Stack>(
       invoke: {
         jump: true as const,
         identifier: funcName,
+        ...(declaration ? { declaration } : {}),
         target: {
-          pointer: { location: "stack" as const, slot: 0 },
+          pointer: {
+            location: "stack" as const,
+            slot: 0,
+          },
         },
         ...(argPointers.length > 0 && {
           arguments: {

--- a/packages/bugc/src/evmgen/generation/function.ts
+++ b/packages/bugc/src/evmgen/generation/function.ts
@@ -31,15 +31,26 @@ function generatePrologue<S extends Stack>(
     // Add JUMPDEST with function entry annotation.
     // After this JUMPDEST executes, the callee's args are
     // on the stack (first arg deepest).
-    const argPointers = params.map((_p, i) => ({
+    const argPointers = params.map((p, i) => ({
+      ...(p.name ? { name: p.name } : {}),
       location: "stack" as const,
       slot: params.length - 1 - i,
     }));
+
+    // Build declaration source range if available
+    const declaration =
+      func.loc && func.sourceId
+        ? {
+            source: { id: func.sourceId },
+            range: func.loc,
+          }
+        : undefined;
 
     const entryInvoke: Format.Program.Context.Invoke = {
       invoke: {
         jump: true as const,
         identifier: func.name || "anonymous",
+        ...(declaration ? { declaration } : {}),
         target: {
           pointer: {
             location: "stack" as const,
@@ -157,7 +168,10 @@ export function generate(
   func: Ir.Function,
   memory: Memory.Function.Info,
   layout: Layout.Function.Info,
-  options: { isUserFunction?: boolean } = {},
+  options: {
+    isUserFunction?: boolean;
+    functions?: Map<string, Ir.Function>;
+  } = {},
 ): {
   instructions: Evm.Instruction[];
   bytecode: number[];
@@ -205,6 +219,7 @@ export function generate(
         isFirstBlock,
         options.isUserFunction || false,
         func,
+        options.functions,
       )(state);
     },
     stateAfterPrologue,

--- a/packages/bugc/src/evmgen/generation/module.ts
+++ b/packages/bugc/src/evmgen/generation/module.ts
@@ -32,6 +32,7 @@ export function generate(
     module.main,
     memory.main,
     blocks.main,
+    { functions: module.functions },
   );
 
   // Collect all warnings
@@ -53,6 +54,7 @@ export function generate(
     if (funcMemory && funcLayout) {
       const funcResult = Function.generate(func, funcMemory, funcLayout, {
         isUserFunction: true,
+        functions: module.functions,
       });
       functionResults.push({
         name,

--- a/packages/bugc/src/ir/spec/function.ts
+++ b/packages/bugc/src/ir/spec/function.ts
@@ -17,6 +17,10 @@ export interface Function {
   blocks: Map<string, Block>;
   /** SSA variable metadata mapping temp IDs to original variables */
   ssaVariables?: Map<string, Function.SsaVariable>;
+  /** Source location of the function declaration */
+  loc?: Ast.SourceLocation;
+  /** Source ID for debug info (inherited from module) */
+  sourceId?: string;
 }
 
 export namespace Function {

--- a/packages/bugc/src/irgen/generate/module.ts
+++ b/packages/bugc/src/irgen/generate/module.ts
@@ -72,6 +72,9 @@ export function* buildModule(
         buildFunction(funcDecl.name, parameters, funcDecl.body),
       );
       if (func) {
+        const moduleState = yield* Process.Modules.current();
+        func.loc = funcDecl.loc ?? undefined;
+        func.sourceId = moduleState.sourceId;
         yield* Process.Functions.addToModule(funcDecl.name, func);
       }
     }


### PR DESCRIPTION
## Summary
- Invoke and return contexts now include `declaration` source ranges pointing to the function definition in source
- Argument group pointers now include parameter names from the function signature
- Adds `loc`/`sourceId` to `Ir.Function` and threads module function metadata through EVM codegen

This enriches debug info so debuggers can link call stack entries to source declarations and display meaningful parameter names alongside argument values.