### PR TITLE
bugc: map return epilogue instructions to source location

### DIFF
--- a/packages/bugc/src/evmgen/call-contexts.test.ts
+++ b/packages/bugc/src/evmgen/call-contexts.test.ts
@@ -358,4 +358,35 @@ code {
       });
     });
   });
+
+  describe("return epilogue source maps", () => {
+    it(
+      "should map return epilogue instructions " + "to source location",
+      async () => {
+        const program = await compileProgram(source);
+
+        // The return epilogue is PUSH/MLOAD/JUMP inside
+        // user functions. Find JUMP instructions that are
+        // NOT invoke contexts — these are return jumps.
+        const returnJumps = program.instructions.filter(
+          (instr) =>
+            instr.operation?.mnemonic === "JUMP" &&
+            !Context.isInvoke(instr.context),
+        );
+
+        // Should have at least one return JUMP (from add)
+        expect(returnJumps.length).toBeGreaterThanOrEqual(1);
+
+        // The return JUMP should have a code context with
+        // source location (not just a remark)
+        const returnJump = returnJumps[0];
+        expect(returnJump.context).toBeDefined();
+        const ctx = returnJump.context as Record<string, unknown>;
+        expect(ctx.code).toBeDefined();
+        const code = ctx.code as Record<string, unknown>;
+        expect(code.source).toEqual({ id: "0" });
+        expect(code.range).toBeDefined();
+      },
+    );
+  });
 });

--- a/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
+++ b/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
@@ -26,24 +26,16 @@ export function generateTerminator<S extends Stack>(
       if (isUserFunction) {
         // Load return PC from the saved slot (not 0x60,
         // which may have been overwritten by nested calls).
+        // Use operationDebug from the IR return terminator
+        // so the epilogue maps back to the return statement.
+        const debug = term.operationDebug;
         return pipe<S>()
           .peek((state, builder) => {
             const pcOffset = state.memory.savedReturnPcOffset ?? 0x60;
-            const returnDebug = {
-              context: {
-                remark: term.value
-                  ? "function-return: return with value"
-                  : "function-return: void return",
-              },
-            };
             return builder
-              .then(PUSHn(BigInt(pcOffset), { debug: returnDebug }), {
-                as: "offset",
-              })
-              .then(MLOAD({ debug: returnDebug }), {
-                as: "counter",
-              })
-              .then(JUMP({ debug: returnDebug }));
+              .then(PUSHn(BigInt(pcOffset), { debug }), { as: "offset" })
+              .then(MLOAD({ debug }), { as: "counter" })
+              .then(JUMP({ debug }));
           })
           .done() as unknown as Transition<S, S>;
       }


### PR DESCRIPTION
## Summary
- Return epilogue (PUSH/MLOAD/JUMP) now carries the source location of the `return` statement instead of a remark-only context
- Uses the IR return terminator's `operationDebug` which already has the source range from irgen
- Adds test verifying return JUMP has `code` context with source location