### PR TITLE
Fix typos and missing CSS classes

### DIFF
--- a/packages/programs-react/src/components/CallInfoPanel.css
+++ b/packages/programs-react/src/components/CallInfoPanel.css
@@ -49,6 +49,10 @@
   flex-shrink: 0;
 }
 
+.call-info-ref-value {
+  display: inline;
+}
+
 .call-info-ref-resolved {
   font-family: monospace;
   font-size: 0.9em;

--- a/packages/programs-react/src/components/CallStackDisplay.css
+++ b/packages/programs-react/src/components/CallStackDisplay.css
@@ -41,6 +41,10 @@
   font-weight: 500;
 }
 
+.call-stack-empty-text {
+  font-style: italic;
+}
+
 .call-stack-parens {
   color: var(--programs-text-muted, #888);
 }

--- a/packages/web/spec/type/concepts.mdx
+++ b/packages/web/spec/type/concepts.mdx
@@ -55,12 +55,12 @@ places additional constraints in addition to what the base schema specifies.
 ## Elementary vs. complex types
 
 Type representations in this schema fall into one of two `class`es: either
-`"elementary"` or `"complex"`. Type representations express this disinction in
+`"elementary"` or `"complex"`. Type representations express this distinction in
 two ways (the optional `"class"` field, and the absence or existence of a
 `"contains"` field).
 
 - Elementary types do not compose any other types. For example, `uint256` is an
-  elementary type. `string` may be an elementary type for languages that whose
+  elementary type. `string` may be an elementary type for languages whose
   semantics treat strings differently than simply an array of characters (like
   Solidity does).
 

--- a/packages/web/src/theme/ProgramExample/CallInfoPanel.css
+++ b/packages/web/src/theme/ProgramExample/CallInfoPanel.css
@@ -49,6 +49,10 @@
   flex-shrink: 0;
 }
 
+.call-info-ref-value {
+  display: inline;
+}
+
 .call-info-ref-resolved {
   font-family: monospace;
   font-size: 0.9em;

--- a/packages/web/src/theme/ProgramExample/CallStackDisplay.css
+++ b/packages/web/src/theme/ProgramExample/CallStackDisplay.css
@@ -41,6 +41,10 @@
   font-weight: 500;
 }
 
+.call-stack-empty-text {
+  font-style: italic;
+}
+
 .call-stack-parens {
   color: var(--programs-text-muted, #888);
 }


### PR DESCRIPTION
## Summary

- Fix "disinction" → "distinction" typo in type concepts spec
- Fix "languages that whose" → "languages whose" grammar error
- Add missing `.call-stack-empty-text` CSS class definition
- Add missing `.call-info-ref-value` CSS class definition
- Applied to both programs-react and web theme copies