### PR TITLE
bugc: add runtime call stack for recursion support

### DIFF
--- a/packages/bugc/src/evmgen/analysis/memory.test.ts
+++ b/packages/bugc/src/evmgen/analysis/memory.test.ts
@@ -89,12 +89,12 @@ describe("Memory Planning", () => {
 
     // Phi destination %3 should be allocated memory
     expect("%3" in memory.allocations).toBe(true);
-    // %1 is allocated first at 0x80, then %3 at 0xa0 (160)
-    expect(memory.allocations["%3"].offset).toBe(0xa0);
+    // %1 is allocated first at 0xa0, then %3 at 0xc0
+    expect(memory.allocations["%3"].offset).toBe(0xc0);
 
     // Cross-block value %1 should also be allocated
     expect("%1" in memory.allocations).toBe(true);
-    expect(memory.allocations["%1"].offset).toBe(0x80);
+    expect(memory.allocations["%1"].offset).toBe(0xa0);
   });
 
   it("should allocate memory for cross-block values", () => {

--- a/packages/bugc/src/evmgen/analysis/memory.ts
+++ b/packages/bugc/src/evmgen/analysis/memory.ts
@@ -30,11 +30,24 @@ export { MemoryError as Error };
  * EVM memory layout following Solidity conventions
  */
 export const regions = {
-  SCRATCH_SPACE_1: 0x00, // 0x00-0x1f: First scratch space slot
-  SCRATCH_SPACE_2: 0x20, // 0x20-0x3f: Second scratch space slot
-  FREE_MEMORY_POINTER: 0x40, // 0x40-0x5f: Dynamic memory pointer
-  ZERO_SLOT: 0x60, // 0x60-0x7f: Zero slot (reserved)
-  STATIC_MEMORY_START: 0x80, // 0x80+: Static allocations start here
+  SCRATCH_SPACE_1: 0x00, // 0x00-0x1f: First scratch space
+  SCRATCH_SPACE_2: 0x20, // 0x20-0x3f: Second scratch space
+  FREE_MEMORY_POINTER: 0x40, // 0x40-0x5f: Dynamic memory ptr
+  RETURN_PC_SCRATCH: 0x60, // 0x60-0x7f: Caller→callee return PC
+  FRAME_POINTER: 0x80, // 0x80-0x9f: Current frame base address
+  STATIC_MEMORY_START: 0xa0, // 0xa0+: Static allocations
+} as const;
+
+/**
+ * Call frame header layout (relative to frame base).
+ * Each user-function call allocates a frame from FMP;
+ * the first two slots store the saved frame pointer
+ * and saved return PC.
+ */
+export const frameHeader = {
+  SAVED_FP: 0x00,
+  SAVED_RETURN_PC: 0x20,
+  LOCALS_START: 0x40,
 } as const;
 
 export interface Allocation {
@@ -93,10 +106,10 @@ export namespace Module {
     result.main = mainMemory.value;
 
     // Process user-defined functions.
-    // Each function's allocations start after the previous
-    // function's end, so all simultaneously-active frames
-    // have non-overlapping memory.
-    let nextFuncOffset = result.main.nextStaticOffset;
+    // Each function gets its own call frame allocated from
+    // FMP at runtime. Offsets are relative to the frame
+    // base, starting after the frame header (saved FP +
+    // saved return PC).
     for (const [name, func] of module.functions) {
       const funcLiveness = liveness.functions[name];
       if (!funcLiveness) {
@@ -109,13 +122,12 @@ export namespace Module {
       }
       const funcMemory = Function.plan(func, funcLiveness, {
         isUserFunction: true,
-        startOffset: nextFuncOffset,
+        startOffset: frameHeader.LOCALS_START,
       });
       if (!funcMemory.success) {
         return funcMemory;
       }
       result.functions[name] = funcMemory.value;
-      nextFuncOffset = funcMemory.value.nextStaticOffset;
     }
 
     return Result.ok(result);
@@ -124,16 +136,22 @@ export namespace Module {
 
 export namespace Function {
   export interface Info {
-    /** Memory allocation info for each value that needs allocation */
+    /** Memory allocation info for each value */
     allocations: Record<string, Allocation>;
-    /** Next available memory offset after all static allocations */
+    /** Next available memory offset after static allocations */
     nextStaticOffset: number;
     /**
-     * Offset where this function saves its return PC.
-     * Only set for user-defined functions that need to
-     * preserve their return address across internal calls.
+     * Frame-relative offset for saved return PC.
+     * Only set for user-defined functions.
      */
     savedReturnPcOffset?: number;
+    /**
+     * Total frame size in bytes. When set, all allocation
+     * offsets are relative to the frame base (loaded from
+     * FRAME_POINTER at 0x80). Frames are allocated from
+     * FMP on entry and deallocated on return.
+     */
+    frameSize?: number;
   }
 
   /**
@@ -212,19 +230,22 @@ export namespace Function {
         nextStaticOffset = currentSlotOffset;
       }
 
-      // Reserve a slot for the saved return PC in user
-      // functions. This is needed because nested calls
-      // overwrite memory[0x60] with their own return PC.
+      // For user functions, the saved return PC lives at a
+      // fixed offset in the frame header. frameSize is the
+      // total frame allocation (header + locals), rounded
+      // up to a slot boundary.
       let savedReturnPcOffset: number | undefined;
+      let frameSize: number | undefined;
       if (options.isUserFunction) {
-        savedReturnPcOffset = nextStaticOffset;
-        nextStaticOffset += SLOT_SIZE;
+        savedReturnPcOffset = frameHeader.SAVED_RETURN_PC;
+        frameSize = nextStaticOffset;
       }
 
       return Result.ok({
         allocations,
         nextStaticOffset,
         savedReturnPcOffset,
+        frameSize,
       });
     } catch (error) {
       return Result.err(

--- a/packages/bugc/src/evmgen/behavioral.test.ts
+++ b/packages/bugc/src/evmgen/behavioral.test.ts
@@ -332,6 +332,63 @@ code {
     });
   });
 
+  describe("recursion", () => {
+    it("should support recursive function calls", async () => {
+      const source = `name RecursionTest;
+
+define {
+  function succ(n: uint256) -> uint256 {
+    return n + 1;
+  };
+  function count(
+    n: uint256, target: uint256
+  ) -> uint256 {
+    if (n < target) {
+      return count(succ(n), target);
+    } else {
+      return n;
+    }
+  };
+}
+
+storage { [0] result: uint256; }
+create { result = 0; }
+code { result = count(0, 5); }`;
+
+      const result = await executeProgram(source, {
+        calldata: "",
+      });
+
+      expect(result.callSuccess).toBe(true);
+      expect(await result.getStorage(0n)).toBe(5n);
+    });
+
+    it("should support simple self-recursion", async () => {
+      const source = `name SimpleRecursion;
+
+define {
+  function factorial(n: uint256) -> uint256 {
+    if (n < 2) {
+      return 1;
+    } else {
+      return n * factorial(n - 1);
+    }
+  };
+}
+
+storage { [0] result: uint256; }
+create { result = 0; }
+code { result = factorial(5); }`;
+
+      const result = await executeProgram(source, {
+        calldata: "",
+      });
+
+      expect(result.callSuccess).toBe(true);
+      expect(await result.getStorage(0n)).toBe(120n);
+    });
+  });
+
   describe("loops", () => {
     it("should execute a for loop", async () => {
       const source = `name Loop;

--- a/packages/bugc/src/evmgen/generation/block.ts
+++ b/packages/bugc/src/evmgen/generation/block.ts
@@ -5,6 +5,7 @@
 import type * as Ast from "#ast";
 import type * as Format from "@ethdebug/format";
 import * as Ir from "#ir";
+import type * as Evm from "#evm";
 import type { Stack } from "#evm";
 
 import { Error, ErrorCode } from "#evmgen/errors";
@@ -47,8 +48,10 @@ export function generate<S extends Stack>(
         },
       }));
 
-      // Initialize memory for first block
-      if (isFirstBlock) {
+      // Initialize memory for first block of main/create.
+      // User functions allocate frames in the prologue
+      // instead — re-initializing here would clobber FP/FMP.
+      if (isFirstBlock && !isUserFunction) {
         const sourceInfo =
           func?.sourceId && func?.loc
             ? { sourceId: func.sourceId, loc: func.loc }
@@ -123,7 +126,8 @@ export function generate<S extends Stack>(
             result = result.then(annotateTop(destId)).then((s) => {
               const allocation = s.memory.allocations[destId];
               if (!allocation) return s;
-              // Spill return value to memory: DUP1, PUSH offset, MSTORE
+              // Spill return value to memory.
+              // DUP1 keeps the value; compute address; MSTORE.
               return {
                 ...s,
                 instructions: [
@@ -133,15 +137,11 @@ export function generate<S extends Stack>(
                     opcode: 0x80,
                     debug: spillDebug,
                   },
-                  {
-                    mnemonic: "PUSH2" as const,
-                    opcode: 0x61,
-                    immediates: [
-                      (allocation.offset >> 8) & 0xff,
-                      allocation.offset & 0xff,
-                    ],
-                    debug: spillDebug,
-                  },
+                  ...computeAddress(
+                    allocation.offset,
+                    s.memory.frameSize !== undefined,
+                    spillDebug,
+                  ),
                   {
                     mnemonic: "MSTORE" as const,
                     opcode: 0x52,
@@ -200,7 +200,7 @@ function generatePhi<S extends Stack>(
   phi: Ir.Block.Phi,
   predecessor: string,
 ): Transition<S, S> {
-  const { PUSHn, MSTORE } = operations;
+  const { PUSHn, ADD, MLOAD, MSTORE } = operations;
 
   const source = phi.sources.get(predecessor);
   if (!source) {
@@ -222,8 +222,20 @@ function generatePhi<S extends Stack>(
             `Phi destination ${phi.dest} not allocated`,
           );
         }
+        if (state.memory.frameSize !== undefined) {
+          return builder
+            .then(PUSHn(BigInt(Memory.regions.FRAME_POINTER)), { as: "offset" })
+            .then(MLOAD(), { as: "b" })
+            .then(PUSHn(BigInt(allocation.offset)), {
+              as: "a",
+            })
+            .then(ADD(), { as: "offset" })
+            .then(MSTORE());
+        }
         return builder
-          .then(PUSHn(BigInt(allocation.offset)), { as: "offset" })
+          .then(PUSHn(BigInt(allocation.offset)), {
+            as: "offset",
+          })
           .then(MSTORE());
       })
       .done()
@@ -261,16 +273,81 @@ function initializeMemory<S extends Stack>(
         } as Format.Program.Context,
       };
 
-  return pipe<S>()
-    .then(PUSHn(BigInt(nextStaticOffset), { debug }), {
-      as: "value",
-    })
-    .then(
-      PUSHn(BigInt(Memory.regions.FREE_MEMORY_POINTER), {
-        debug,
-      }),
-      { as: "offset" },
-    )
-    .then(MSTORE({ debug }))
-    .done();
+  const { PUSH0 } = operations;
+
+  return (
+    pipe<S>()
+      .then(PUSHn(BigInt(nextStaticOffset), { debug }), {
+        as: "value",
+      })
+      .then(
+        PUSHn(BigInt(Memory.regions.FREE_MEMORY_POINTER), {
+          debug,
+        }),
+        { as: "offset" },
+      )
+      .then(MSTORE({ debug }))
+      // Initialize frame pointer to 0 (no active frame)
+      .then(PUSH0({ debug }), { as: "value" })
+      .then(PUSHn(BigInt(Memory.regions.FRAME_POINTER), { debug }), {
+        as: "offset",
+      })
+      .then(MSTORE({ debug }))
+      .done()
+  );
+}
+
+/**
+ * Emit instructions to compute a memory address.
+ *
+ * For frame-based functions, emits PUSH FP; MLOAD;
+ * PUSH offset; ADD. For absolute mode, emits PUSH2
+ * with the offset encoded directly.
+ */
+function computeAddress(
+  offset: number,
+  isFrameBased: boolean,
+  debug: Evm.Instruction["debug"],
+): Evm.Instruction[] {
+  if (isFrameBased) {
+    return [
+      ...pushImm(Memory.regions.FRAME_POINTER, debug),
+      { mnemonic: "MLOAD" as const, opcode: 0x51, debug },
+      ...pushImm(offset, debug),
+      { mnemonic: "ADD" as const, opcode: 0x01, debug },
+    ];
+  }
+  return [
+    {
+      mnemonic: "PUSH2" as const,
+      opcode: 0x61,
+      immediates: [(offset >> 8) & 0xff, offset & 0xff],
+      debug,
+    },
+  ];
+}
+
+/** PUSH an integer as the smallest PUSHn. */
+function pushImm(
+  value: number,
+  debug: Evm.Instruction["debug"],
+): Evm.Instruction[] {
+  if (value === 0) {
+    return [{ mnemonic: "PUSH0", opcode: 0x5f, debug }];
+  }
+  const bytes: number[] = [];
+  let v = value;
+  while (v > 0) {
+    bytes.unshift(v & 0xff);
+    v >>= 8;
+  }
+  const n = bytes.length;
+  return [
+    {
+      mnemonic: `PUSH${n}`,
+      opcode: 0x5f + n,
+      immediates: bytes,
+      debug,
+    },
+  ];
 }

--- a/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
+++ b/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
@@ -1,7 +1,9 @@
 import type * as Format from "@ethdebug/format";
 import type * as Ir from "#ir";
+import type * as Evm from "#evm";
 import type { Stack } from "#evm";
 import type { State } from "#evmgen/state";
+import { Memory } from "#evmgen/analysis";
 
 import { type Transition, operations, pipe } from "#evmgen/operations";
 
@@ -355,23 +357,81 @@ function generateReturnEpilogue<S extends Stack>(
       };
     }
 
-    // Load return PC from saved slot and jump back.
-    const pcOffset = s.memory.savedReturnPcOffset ?? 0x60;
+    // Deallocate frame and jump to saved return PC.
+    //
+    // fp = mem[FRAME_POINTER]
+    // return_pc = mem[fp + SAVED_RETURN_PC]
+    // old_fp = mem[fp + SAVED_FP]  (= mem[fp])
+    // mem[FRAME_POINTER] = old_fp
+    // mem[FREE_MEMORY_POINTER] = fp  (deallocate)
+    // JUMP return_pc
+    const FP = Memory.regions.FRAME_POINTER;
+    const FMP = Memory.regions.FREE_MEMORY_POINTER;
+    const pcOff = Memory.frameHeader.SAVED_RETURN_PC;
+
     s = {
       ...s,
       instructions: [
         ...s.instructions,
-        {
-          mnemonic: "PUSH2",
-          opcode: 0x61,
-          immediates: [(pcOffset >> 8) & 0xff, pcOffset & 0xff],
-          debug,
-        },
+        // fp
+        ...pushImm(FP, debug),
         { mnemonic: "MLOAD", opcode: 0x51, debug },
+        // Stack: [fp, ...]
+
+        // return_pc = mem[fp + SAVED_RETURN_PC]
+        { mnemonic: "DUP1", opcode: 0x80, debug },
+        ...pushImm(pcOff, debug),
+        { mnemonic: "ADD", opcode: 0x01, debug },
+        { mnemonic: "MLOAD", opcode: 0x51, debug },
+        // Stack: [return_pc, fp, ...]
+
+        // old_fp = mem[fp] (SAVED_FP offset is 0)
+        { mnemonic: "SWAP1", opcode: 0x90, debug },
+        // Stack: [fp, return_pc, ...]
+        { mnemonic: "DUP1", opcode: 0x80, debug },
+        { mnemonic: "MLOAD", opcode: 0x51, debug },
+        // Stack: [old_fp, fp, return_pc, ...]
+
+        // mem[FRAME_POINTER] = old_fp
+        { mnemonic: "DUP1", opcode: 0x80, debug },
+        ...pushImm(FP, debug),
+        { mnemonic: "MSTORE", opcode: 0x52, debug },
+        // Stack: [old_fp, fp, return_pc, ...]
+
+        // mem[FREE_MEMORY_POINTER] = fp (deallocate)
+        { mnemonic: "POP", opcode: 0x50, debug },
+        // Stack: [fp, return_pc, ...]
+        ...pushImm(FMP, debug),
+        { mnemonic: "MSTORE", opcode: 0x52, debug },
+        // Stack: [return_pc, ...]
+
+        // JUMP
         { mnemonic: "JUMP", opcode: 0x56, debug },
       ],
     };
 
     return s;
   }) as Transition<S, Stack>;
+}
+
+/** PUSH an integer as the smallest PUSHn. */
+function pushImm(value: number, debug: Ir.Block.Debug): Evm.Instruction[] {
+  if (value === 0) {
+    return [{ mnemonic: "PUSH0", opcode: 0x5f, debug }];
+  }
+  const bytes: number[] = [];
+  let v = value;
+  while (v > 0) {
+    bytes.unshift(v & 0xff);
+    v >>= 8;
+  }
+  const n = bytes.length;
+  return [
+    {
+      mnemonic: `PUSH${n}`,
+      opcode: 0x5f + n,
+      immediates: bytes,
+      debug,
+    },
+  ];
 }

--- a/packages/bugc/src/evmgen/generation/function.test.ts
+++ b/packages/bugc/src/evmgen/generation/function.test.ts
@@ -46,9 +46,10 @@ describe("Function.generate", () => {
 
     const { instructions } = generate(func, memory, layout);
 
-    // Should have memory initialization (PUSH1 0x80, PUSH1 0x40, MSTORE) followed by PUSH1 42
-    // No JUMPDEST for entry with no predecessors, no STOP since it's the last block
-    expect(instructions).toHaveLength(4);
+    // Memory init: FMP (PUSH 0x80, PUSH 0x40, MSTORE)
+    //   then FP=0 (PUSH0, PUSH 0x80, MSTORE)
+    //   then PUSH1 42
+    expect(instructions).toHaveLength(7);
     expect(instructions[0]).toMatchObject({
       mnemonic: "PUSH1",
       immediates: [0x80],
@@ -61,6 +62,16 @@ describe("Function.generate", () => {
       mnemonic: "MSTORE",
     });
     expect(instructions[3]).toMatchObject({
+      mnemonic: "PUSH0",
+    });
+    expect(instructions[4]).toMatchObject({
+      mnemonic: "PUSH1",
+      immediates: [0x80],
+    });
+    expect(instructions[5]).toMatchObject({
+      mnemonic: "MSTORE",
+    });
+    expect(instructions[6]).toMatchObject({
       mnemonic: "PUSH1",
       immediates: [42],
     });

--- a/packages/bugc/src/evmgen/generation/function.ts
+++ b/packages/bugc/src/evmgen/generation/function.ts
@@ -8,7 +8,7 @@ import type * as Evm from "#evm";
 import type { Stack } from "#evm";
 
 import type { State } from "#evmgen/state";
-import type { Layout, Memory } from "#evmgen/analysis";
+import { type Layout, Memory } from "#evmgen/analysis";
 import type { Error as EvmgenError } from "#evmgen/errors";
 
 import * as Block from "./block.js";
@@ -77,126 +77,28 @@ function generatePrologue<S extends Stack>(
       ],
     };
 
-    // Store each parameter to memory and pop from stack
-    // Stack layout on entry: [arg0, arg1, ..., argN]
-    // Return PC is already in memory at 0x60 (stored by caller)
-    // Pop and store each arg from argN down to arg0
+    const d = makePrologueDebug(func);
+    const frameSize = currentState.memory.frameSize;
 
-    const prologueDebug =
-      func.sourceId && func.loc
-        ? {
-            context: {
-              gather: [
-                {
-                  remark: `prologue: store ${params.length} parameter(s) to memory`,
-                },
-                {
-                  code: {
-                    source: { id: func.sourceId },
-                    range: func.loc,
-                  },
-                },
-              ],
-            } as Format.Program.Context,
-          }
-        : {
-            context: {
-              remark: `prologue: store ${params.length} parameter(s) to memory`,
-            } as Format.Program.Context,
-          };
+    if (frameSize !== undefined) {
+      // Allocate call frame from FMP and save context.
+      // Stack on entry: [argN, ..., arg1, arg0]
+      currentState = emitFrameAlloc(currentState, frameSize, d);
+      // Stack: [new_fp, argN, ..., arg0]
 
-    for (let i = params.length - 1; i >= 0; i--) {
-      const param = params[i];
-      const allocation = currentState.memory.allocations[param.tempId];
+      // Pop new_fp — it's now stored at FRAME_POINTER.
+      currentState = emit(currentState, d, { mnemonic: "POP", opcode: 0x50 });
+      // Stack: [argN, ..., arg0]
 
-      if (!allocation) continue;
-
-      // Push memory offset
-      const highByte = (allocation.offset >> 8) & 0xff;
-      const lowByte = allocation.offset & 0xff;
-      currentState = {
-        ...currentState,
-        instructions: [
-          ...currentState.instructions,
-          {
-            mnemonic: "PUSH2",
-            opcode: 0x61,
-            immediates: [highByte, lowByte],
-            debug: prologueDebug,
-          },
-        ],
-      };
-
-      // MSTORE pops arg and offset
-      currentState = {
-        ...currentState,
-        instructions: [
-          ...currentState.instructions,
-          {
-            mnemonic: "MSTORE",
-            opcode: 0x52,
-            debug: prologueDebug,
-          },
-        ],
-      };
-    }
-
-    // Save the return PC from 0x60 to a dedicated slot
-    // so nested function calls don't clobber it.
-    const savedPcOffset = currentState.memory.savedReturnPcOffset;
-    if (savedPcOffset !== undefined) {
-      const savePcDebug =
-        func.sourceId && func.loc
-          ? {
-              context: {
-                gather: [
-                  {
-                    remark: `prologue: save return PC to 0x${savedPcOffset.toString(16)}`,
-                  },
-                  {
-                    code: {
-                      source: { id: func.sourceId },
-                      range: func.loc,
-                    },
-                  },
-                ],
-              } as Format.Program.Context,
-            }
-          : {
-              context: {
-                remark: `prologue: save return PC to 0x${savedPcOffset.toString(16)}`,
-              } as Format.Program.Context,
-            };
-      const highByte = (savedPcOffset >> 8) & 0xff;
-      const lowByte = savedPcOffset & 0xff;
-      currentState = {
-        ...currentState,
-        instructions: [
-          ...currentState.instructions,
-          {
-            mnemonic: "PUSH1",
-            opcode: 0x60,
-            immediates: [0x60],
-            debug: savePcDebug,
-          },
-          {
-            mnemonic: "MLOAD",
-            opcode: 0x51,
-            debug: savePcDebug,
-          },
-          {
-            mnemonic: "PUSH2",
-            opcode: 0x61,
-            immediates: [highByte, lowByte],
-            debug: savePcDebug,
-          },
-          {
-            mnemonic: "MSTORE",
-            opcode: 0x52,
-            debug: savePcDebug,
-          },
-        ],
-      };
+      // Store each param to its frame-relative slot.
+      // PUSH FP; MLOAD; PUSH offset; ADD produces the
+      // address on top; the arg is second; MSTORE
+      // consumes both.
+      for (let i = params.length - 1; i >= 0; i--) {
+        const alloc = currentState.memory.allocations[params[i].tempId];
+        if (!alloc) continue;
+        currentState = emitFpRelativeStore(currentState, alloc.offset, d);
+      }
     }
 
     // Return with empty stack
@@ -206,6 +108,181 @@ function generatePrologue<S extends Stack>(
       brands: [],
     } as State<readonly []>;
   }) as Transition<S, readonly []>;
+}
+
+// ----- prologue helpers -----
+
+const { FRAME_POINTER, FREE_MEMORY_POINTER, RETURN_PC_SCRATCH } =
+  Memory.regions;
+const { SAVED_RETURN_PC } = Memory.frameHeader;
+
+type Debug = Evm.Instruction["debug"];
+type Inst = Omit<Evm.Instruction, "debug">;
+
+/** Append instructions to state, attaching debug. */
+function emit<S extends Stack>(
+  state: State<S>,
+  debug: Debug,
+  ...instrs: Inst[]
+): State<S> {
+  return {
+    ...state,
+    instructions: [
+      ...state.instructions,
+      ...instrs.map((i) => ({ ...i, debug })),
+    ],
+  };
+}
+
+/** PUSH an integer as the smallest PUSHn. */
+function pushImm(value: number, debug: Debug): Evm.Instruction[] {
+  if (value === 0) {
+    return [{ mnemonic: "PUSH0", opcode: 0x5f, debug }];
+  }
+  const bytes: number[] = [];
+  let v = value;
+  while (v > 0) {
+    bytes.unshift(v & 0xff);
+    v >>= 8;
+  }
+  const n = bytes.length;
+  return [
+    {
+      mnemonic: `PUSH${n}`,
+      opcode: 0x5f + n,
+      immediates: bytes,
+      debug,
+    },
+  ];
+}
+
+/**
+ * Emit frame allocation sequence.
+ *
+ * Pushes new_fp onto the stack, bumps FMP, saves old FP
+ * and return PC into the new frame, updates FRAME_POINTER.
+ *
+ * Stack effect: [...args] → [new_fp, ...args]
+ */
+function emitFrameAlloc<S extends Stack>(
+  state: State<S>,
+  frameSize: number,
+  debug: Debug,
+): State<S> {
+  let s = state;
+
+  // new_fp = mem[FMP]
+  s = emit(s, debug, ...pushImm(FREE_MEMORY_POINTER, debug), {
+    mnemonic: "MLOAD",
+    opcode: 0x51,
+  });
+  // Stack: [new_fp, args...]
+
+  // mem[FMP] = new_fp + frameSize
+  s = emit(
+    s,
+    debug,
+    { mnemonic: "DUP1", opcode: 0x80 },
+    ...pushImm(frameSize, debug),
+    { mnemonic: "ADD", opcode: 0x01 },
+    ...pushImm(FREE_MEMORY_POINTER, debug),
+    { mnemonic: "MSTORE", opcode: 0x52 },
+  );
+
+  // frame[SAVED_FP] = old FP
+  // old_fp = mem[FRAME_POINTER]
+  s = emit(
+    s,
+    debug,
+    ...pushImm(FRAME_POINTER, debug),
+    { mnemonic: "MLOAD", opcode: 0x51 },
+    // Stack: [old_fp, new_fp, args...]
+    { mnemonic: "DUP2", opcode: 0x81 },
+    // Stack: [new_fp, old_fp, new_fp, args...]
+    { mnemonic: "MSTORE", opcode: 0x52 },
+    // MSTORE(offset=new_fp, value=old_fp)
+    // → stores old_fp at new_fp+0 (SAVED_FP=0)
+    // Stack: [new_fp, args...]
+  );
+
+  // mem[FRAME_POINTER] = new_fp
+  s = emit(
+    s,
+    debug,
+    { mnemonic: "DUP1", opcode: 0x80 },
+    ...pushImm(FRAME_POINTER, debug),
+    { mnemonic: "MSTORE", opcode: 0x52 },
+  );
+
+  // frame[SAVED_RETURN_PC] = mem[RETURN_PC_SCRATCH]
+  s = emit(
+    s,
+    debug,
+    ...pushImm(RETURN_PC_SCRATCH, debug),
+    { mnemonic: "MLOAD", opcode: 0x51 },
+    // Stack: [return_pc, new_fp, args...]
+    { mnemonic: "DUP2", opcode: 0x81 },
+    // Stack: [new_fp, return_pc, new_fp, args...]
+    ...pushImm(SAVED_RETURN_PC, debug),
+    { mnemonic: "ADD", opcode: 0x01 },
+    // Stack: [new_fp+0x20, return_pc, new_fp, args...]
+    { mnemonic: "MSTORE", opcode: 0x52 },
+    // MSTORE(offset=new_fp+0x20, value=return_pc)
+    // Stack: [new_fp, args...]
+  );
+
+  return s;
+}
+
+/**
+ * Emit FP-relative MSTORE.
+ *
+ * Computes mem[FRAME_POINTER] + offset and stores the
+ * current TOS value there. Consumes TOS.
+ *
+ * Stack effect: [value, ...] → [...]
+ */
+function emitFpRelativeStore<S extends Stack>(
+  state: State<S>,
+  offset: number,
+  debug: Debug,
+): State<S> {
+  // Stack: [value, ...]
+  // → PUSH FP; MLOAD; PUSH offset; ADD
+  // Stack: [fp+offset, value, ...]
+  // → MSTORE (offset=fp+offset, value=value)
+  // Stack: [...]
+  return emit(
+    state,
+    debug,
+    ...pushImm(FRAME_POINTER, debug),
+    { mnemonic: "MLOAD", opcode: 0x51 },
+    ...pushImm(offset, debug),
+    { mnemonic: "ADD", opcode: 0x01 },
+    { mnemonic: "MSTORE", opcode: 0x52 },
+  );
+}
+
+function makePrologueDebug(func: Ir.Function): Debug {
+  return func.sourceId && func.loc
+    ? {
+        context: {
+          gather: [
+            { remark: "prologue: allocate call frame" },
+            {
+              code: {
+                source: { id: func.sourceId },
+                range: func.loc,
+              },
+            },
+          ],
+        } as Format.Program.Context,
+      }
+    : {
+        context: {
+          remark: "prologue: allocate call frame",
+        } as Format.Program.Context,
+      };
 }
 
 /**

--- a/packages/bugc/src/evmgen/generation/instructions/binary.ts
+++ b/packages/bugc/src/evmgen/generation/instructions/binary.ts
@@ -6,8 +6,22 @@ import { type Transition, operations, pipe, rebrand } from "#evmgen/operations";
 
 import { loadValue, storeValueIfNeeded } from "../values/index.js";
 
-const { ADD, SUB, MUL, DIV, MOD, EQ, LT, GT, AND, OR, ISZERO, SHL, SHR } =
-  operations;
+const {
+  ADD,
+  SUB,
+  MUL,
+  DIV,
+  MOD,
+  EQ,
+  LT,
+  GT,
+  AND,
+  OR,
+  ISZERO,
+  SHL,
+  SHR,
+  SWAP1,
+} = operations;
 
 /**
  * Generate code for binary operations
@@ -23,10 +37,25 @@ export function generateBinary<S extends Stack>(
     ) => State<readonly [Stack.Brand, ...S]>;
   } = {
     add: ADD({ debug }),
-    sub: SUB({ debug }),
+    // Non-commutative ops: operands load as [right=a,
+    // left=b] but EVM computes TOS op TOS-1 = right op
+    // left. SWAP1 puts left on TOS before the operation.
+    sub: pipe<readonly ["a", "b", ...S]>()
+      .then(SWAP1({ debug }))
+      .then(rebrand<"b", "a", "a", "b">({ 1: "a", 2: "b" }))
+      .then(SUB({ debug }))
+      .done(),
     mul: MUL({ debug }),
-    div: DIV({ debug }),
-    mod: MOD({ debug }),
+    div: pipe<readonly ["a", "b", ...S]>()
+      .then(SWAP1({ debug }))
+      .then(rebrand<"b", "a", "a", "b">({ 1: "a", 2: "b" }))
+      .then(DIV({ debug }))
+      .done(),
+    mod: pipe<readonly ["a", "b", ...S]>()
+      .then(SWAP1({ debug }))
+      .then(rebrand<"b", "a", "a", "b">({ 1: "a", 2: "b" }))
+      .then(MOD({ debug }))
+      .done(),
     shl: pipe<readonly ["a", "b", ...S]>()
       .then(rebrand<"a", "shift", "b", "value">({ 1: "shift", 2: "value" }))
       .then(SHL({ debug }))

--- a/packages/bugc/src/evmgen/generation/values/load.ts
+++ b/packages/bugc/src/evmgen/generation/values/load.ts
@@ -2,17 +2,23 @@ import type * as Ir from "#ir";
 import * as Evm from "#evm";
 import type { Stack } from "#evm";
 import { type Transition, operations, pipe } from "#evmgen/operations";
+import { Memory } from "#evmgen/analysis";
 
 import { valueId, annotateTop } from "./identify.js";
 
 /**
- * Load a value onto the stack
+ * Load a value onto the stack.
+ *
+ * When the function uses call frames (memory.frameSize is
+ * set), allocation offsets are relative to the frame base
+ * stored at FRAME_POINTER (0x80). The load sequence becomes
+ * PUSH 0x80 / MLOAD / PUSH offset / ADD / MLOAD.
  */
 export const loadValue = <S extends Stack>(
   value: Ir.Value,
   options?: Evm.InstructionOptions,
 ): Transition<S, readonly ["value", ...S]> => {
-  const { PUSHn, DUPn, MLOAD } = operations;
+  const { PUSHn, DUPn, ADD, MLOAD } = operations;
 
   const id = valueId(value);
 
@@ -35,6 +41,18 @@ export const loadValue = <S extends Stack>(
       // Check if in memory
       if (id in state.memory.allocations) {
         const offset = state.memory.allocations[id].offset;
+        if (state.memory.frameSize !== undefined) {
+          // FP-relative: load frame base, add offset
+          return builder
+            .then(PUSHn(BigInt(Memory.regions.FRAME_POINTER), options), {
+              as: "offset",
+            })
+            .then(MLOAD(options), { as: "b" })
+            .then(PUSHn(BigInt(offset), options), { as: "a" })
+            .then(ADD(options), { as: "offset" })
+            .then(MLOAD(options))
+            .then(annotateTop(id));
+        }
         return builder
           .then(PUSHn(BigInt(offset), options), { as: "offset" })
           .then(MLOAD(options))

--- a/packages/bugc/src/evmgen/generation/values/store.ts
+++ b/packages/bugc/src/evmgen/generation/values/store.ts
@@ -1,17 +1,23 @@
 import * as Evm from "#evm";
 import type { Stack } from "#evm";
 import { type Transition, operations, pipe } from "#evmgen/operations";
+import { Memory } from "#evmgen/analysis";
 
 import { annotateTop } from "./identify.js";
 
 /**
- * Store a value to memory if it needs to be persisted
+ * Store a value to memory if it needs to be persisted.
+ *
+ * When the function uses call frames (memory.frameSize is
+ * set), the store address is FP-relative: load frame base
+ * from FRAME_POINTER, add the allocation offset, then
+ * MSTORE.
  */
 export const storeValueIfNeeded = <S extends Stack>(
   destId: string,
   options?: Evm.InstructionOptions,
 ): Transition<readonly ["value", ...S], readonly ["value", ...S]> => {
-  const { PUSHn, DUP2, SWAP1, MSTORE } = operations;
+  const { PUSHn, ADD, DUP2, SWAP1, MLOAD, MSTORE } = operations;
 
   return (
     pipe<readonly ["value", ...S]>()
@@ -22,8 +28,30 @@ export const storeValueIfNeeded = <S extends Stack>(
         if (allocation === undefined) {
           return builder;
         }
+        if (state.memory.frameSize !== undefined) {
+          // FP-relative store:
+          // stack: [value, ...]
+          // → PUSH FP_SLOT / MLOAD / PUSH offset / ADD
+          //   → [addr, value, ...]
+          // → DUP2 / SWAP1 / MSTORE
+          //   → [value, ...]
+          return builder
+            .then(PUSHn(BigInt(Memory.regions.FRAME_POINTER), options), {
+              as: "offset",
+            })
+            .then(MLOAD(options), { as: "b" })
+            .then(PUSHn(BigInt(allocation.offset), options), {
+              as: "a",
+            })
+            .then(ADD(options), { as: "offset" })
+            .then(DUP2(options))
+            .then(SWAP1(options))
+            .then(MSTORE(options));
+        }
         return builder
-          .then(PUSHn(BigInt(allocation.offset), options), { as: "offset" })
+          .then(PUSHn(BigInt(allocation.offset), options), {
+            as: "offset",
+          })
           .then(DUP2(options))
           .then(SWAP1(options))
           .then(MSTORE(options));


### PR DESCRIPTION
## Summary
- Implement FMP-based call frames so user-defined functions can recurse. Each call allocates a frame from the free memory pointer containing saved FP, saved return PC, and locals. Returns deallocate by restoring FP and FMP.
- Fix pre-existing SUB/DIV/MOD operand ordering bug (EVM computed right op left instead of left op right).
- Add behavioral tests for recursion (succ/count, factorial).