### PR TITLE
docs: add recursive function call tracing example

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing-examples.ts
+++ b/packages/web/docs/core-schemas/programs/tracing-examples.ts
@@ -71,3 +71,30 @@ create {
 code {
   result = add(3, 4);
 }`;
+
+export const recursiveCount = `name Counter;
+
+define {
+  function succ(n: uint256) -> uint256 {
+    return n + 1;
+  };
+  function count(n: uint256, target: uint256) -> uint256 {
+    if (n < target) {
+      return count(succ(n), target);
+    } else {
+      return n;
+    }
+  };
+}
+
+storage {
+  [0] result: uint256;
+}
+
+create {
+  result = 0;
+}
+
+code {
+  result = count(0, 5);
+}`;

--- a/packages/web/docs/core-schemas/programs/tracing.mdx
+++ b/packages/web/docs/core-schemas/programs/tracing.mdx
@@ -10,6 +10,7 @@ import {
   thresholdCheck,
   multipleStorageSlots,
   functionCallAndReturn,
+  recursiveCount,
 } from "./tracing-examples";
 
 # Tracing execution
@@ -93,6 +94,17 @@ trace. Watch for **invoke** contexts on the JUMP into `add` and
   title="Function call and return"
   description="Calls an internal add function and stores the result"
   source={functionCallAndReturn}
+/>
+
+Recursive calls produce nested invoke/return pairs. In this
+example, `count` calls `succ` and then calls itself repeatedly
+until `n` reaches `target`. Each recursive call adds a frame
+to the call stack:
+
+<TraceExample
+  title="Recursive function calls"
+  description="Counts from 0 to 5 using recursive succ and count functions"
+  source={recursiveCount}
 />
 
 As you step through, three phases are visible:


### PR DESCRIPTION
## Summary

- Adds a recursive `count`/`succ` example to the tracing docs, showing nested invoke/return contexts from recursive function calls
- Source string in `tracing-examples.ts` with proper indentation (safe from prettier)
- Placed alongside the Adder example in the "Tracing through a function call" section