### PR TITLE
docs: replace recursive example with isEven/isOdd mutual recursion

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing-examples.ts
+++ b/packages/web/docs/core-schemas/programs/tracing-examples.ts
@@ -72,18 +72,16 @@ code {
   result = add(3, 4);
 }`;
 
-export const recursiveCount = `name Counter;
+export const mutualRecursion = `name EvenOdd;
 
 define {
-  function succ(n: uint256) -> uint256 {
-    return n + 1;
+  function isEven(n: uint256) -> uint256 {
+    if (n == 0) { return 1; }
+    else { return isOdd(n - 1); }
   };
-  function count(n: uint256, target: uint256) -> uint256 {
-    if (n < target) {
-      return count(succ(n), target);
-    } else {
-      return n;
-    }
+  function isOdd(n: uint256) -> uint256 {
+    if (n == 0) { return 0; }
+    else { return isEven(n - 1); }
   };
 }
 
@@ -96,5 +94,5 @@ create {
 }
 
 code {
-  result = count(0, 5);
+  result = isEven(4);
 }`;

--- a/packages/web/docs/core-schemas/programs/tracing.mdx
+++ b/packages/web/docs/core-schemas/programs/tracing.mdx
@@ -10,7 +10,7 @@ import {
   thresholdCheck,
   multipleStorageSlots,
   functionCallAndReturn,
-  recursiveCount,
+  mutualRecursion,
 } from "./tracing-examples";
 
 # Tracing execution
@@ -96,15 +96,15 @@ trace. Watch for **invoke** contexts on the JUMP into `add` and
   source={functionCallAndReturn}
 />
 
-Recursive calls produce nested invoke/return pairs. In this
-example, `count` calls `succ` and then calls itself repeatedly
-until `n` reaches `target`. Each recursive call adds a frame
+Mutual recursion produces alternating invoke/return pairs. In
+this example, `isEven` and `isOdd` call each other, bouncing
+back and forth until `n` reaches zero. Each call adds a frame
 to the call stack:
 
 <TraceExample
-  title="Recursive function calls"
-  description="Counts from 0 to 5 using recursive succ and count functions"
-  source={recursiveCount}
+  title="Mutual recursion"
+  description="Checks if 4 is even using mutually recursive isEven/isOdd"
+  source={mutualRecursion}
 />
 
 As you step through, three phases are visible:


### PR DESCRIPTION
## Summary

- Replaces the succ/count recursive example with an isEven/isOdd mutual recursion example
- Better demonstrates alternating invoke/return contexts between two functions
- Adder example unchanged