### PR TITLE
bugc: emit tailcall transform context on TCO back-edge

### DIFF
--- a/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
+++ b/packages/bugc/src/evmgen/generation/control-flow/terminator.ts
@@ -411,16 +411,24 @@ function generateReturnEpilogue<S extends Stack>(
 /**
  * Build JUMP instruction options for a TCO-replaced tail call.
  *
- * The JUMP carries BOTH discriminators on a single flat
- * context object:
+ * The JUMP carries three keys on a single flat context
+ * object:
  *   - return: the previous iteration's return
  *   - invoke: the new iteration's call
+ *   - transform: ["tailcall"]
  *
  * Semantically the debugger sees frame depth stay constant
  * across the back-edge JUMP: the previous frame pops, the
  * new one pushes, on the same instruction. The function's
  * terminal RETURN (elsewhere) emits a return context
  * normally, popping the final iteration's frame.
+ *
+ * The `transform: ["tailcall"]` key is an additive
+ * annotation: it does not replace the invoke/return pair
+ * (which state the source-level facts) but tells debuggers
+ * the pair was realized as a TCO back-edge rather than a
+ * real frame push/pop, so they can avoid inventing a
+ * spurious frame.
  *
  * The invoke mirrors the normal caller-JUMP invoke
  * (identity + declaration + code target, no argument
@@ -443,7 +451,8 @@ function buildTailCallJumpOptions(tailCall: Ir.Block.TailCall): {
       : undefined;
 
   const combined: Format.Program.Context.Return &
-    Format.Program.Context.Invoke = {
+    Format.Program.Context.Invoke &
+    Format.Program.Context.Transform = {
     return: {
       identifier: tailCall.function,
       ...(declaration ? { declaration } : {}),
@@ -460,6 +469,7 @@ function buildTailCallJumpOptions(tailCall: Ir.Block.TailCall): {
         },
       },
     },
+    transform: ["tailcall"],
   };
 
   return { debug: { context: combined as Format.Program.Context } };

--- a/packages/bugc/src/evmgen/optimizer-contexts.test.ts
+++ b/packages/bugc/src/evmgen/optimizer-contexts.test.ts
@@ -497,6 +497,17 @@ code { r = count(0, 5); }`;
               Context.isReturn(instr.context),
           );
           expect(tcoJump).toBeDefined();
+
+          // The same back-edge JUMP additionally carries a
+          // `transform: ["tailcall"]` context. This is an
+          // additive annotation telling debuggers the
+          // invoke/return pair was realized as a TCO
+          // back-edge rather than a real frame push/pop.
+          expect(Context.isTransform(tcoJump!.context)).toBe(true);
+          expect(
+            (tcoJump!.context as Format.Program.Context.Transform).transform,
+          ).toContain("tailcall");
+
           const ctx = tcoJump!.context as Format.Program.Context.Invoke;
           const invocation = ctx.invoke;
           expect(Invocation.isInternalCall(invocation)).toBe(true);


### PR DESCRIPTION
Emits a `transform: ["tailcall"]` context on the TCO back-edge JUMP, using the transform schema added in #212.

The TCO back-edge JUMP already carries a flat context with both `invoke` (the new iteration's call) and `return` (the previous iteration's return). This adds a third sibling key, `transform: ["tailcall"]`, marking the instruction as a tail-call-optimized back-edge.

Per #212's design, this is an **additive** annotation — it does not replace the invoke/return pair (which state the source-level facts), but tells debuggers the pair was realized as a TCO back-edge rather than a real frame push/pop, so they can avoid inventing a spurious frame. Consumers that ignore transform contexts still get a sound source-level view from invoke/return alone. Flat sibling-key composition (no `gather`) follows the convention #212 established.

## Changes
- `evmgen/generation/control-flow/terminator.ts` — `buildTailCallJumpOptions` widens the emitted context type to `Return & Invoke & Transform` and adds `transform: ["tailcall"]`.
- `evmgen/optimizer-contexts.test.ts` — asserts the back-edge JUMP carries `transform` containing `"tailcall"` at optimizer levels 2 and 3.

## Verification
- `yarn build` + full bugc suite green (406 passed, 22 pre-existing skips).
- Drove an actual level-2 compile of the tail-recursive `count` program: runtime program emits exactly one back-edge JUMP with `transform: ["tailcall"]` + `invoke` (id `count`, code target patched to `0x78`) + `return`.