### PR TITLE
docs: add tail-call optimization tracing example

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing-examples.ts
+++ b/packages/web/docs/core-schemas/programs/tracing-examples.ts
@@ -96,3 +96,45 @@ create {
 code {
   result = isEven(4);
 }`;
+
+export const tailRecursiveSum = `name TailSum;
+
+define {
+  function sum(n: uint256, acc: uint256) -> uint256 {
+    if (n == 0) { return acc; }
+    else { return sum(n - 1, acc + n); }
+  };
+}
+
+storage {
+  [0] result: uint256;
+}
+
+create {
+  result = 0;
+}
+
+code {
+  result = sum(5, 0);
+}`;
+
+export const tailRecursiveFactorial = `name TailFactorial;
+
+define {
+  function fact(n: uint256, acc: uint256) -> uint256 {
+    if (n == 0) { return acc; }
+    else { return fact(n - 1, acc * n); }
+  };
+}
+
+storage {
+  [0] result: uint256;
+}
+
+create {
+  result = 0;
+}
+
+code {
+  result = fact(5, 1);
+}`;

--- a/packages/web/docs/core-schemas/programs/tracing.mdx
+++ b/packages/web/docs/core-schemas/programs/tracing.mdx
@@ -11,6 +11,8 @@ import {
   multipleStorageSlots,
   functionCallAndReturn,
   mutualRecursion,
+  tailRecursiveSum,
+  tailRecursiveFactorial,
 } from "./tracing-examples";
 
 # Tracing execution
@@ -244,6 +246,75 @@ code instead of (or alongside) a reason pointer:
   }
 }`}
 </SchemaExample>
+
+## Tail-call optimization
+
+The recursion examples above push a new frame for every call — step
+through them and watch the call stack grow. A compiler can often avoid
+that. When a recursive call sits in **tail position** — its result is
+returned directly, with no further work after it — the compiler can
+reuse the current frame instead of pushing a new one. This is
+**tail-call optimization** (TCO), and it turns recursion into a loop.
+
+The two programs below are written so bugc's optimizer folds them. Each
+accumulates its result in an `acc` parameter and hands it to the next
+call in tail position, so no work is left pending on the stack.
+
+Use the optimizer control on each example to switch between level 0
+(no optimization) and level 2 (TCO on), then step through and compare
+the call stack.
+
+<TraceExample
+  title="Tail-recursive sum"
+  description="Sums 1..5 with an accumulator; TCO folds it into a loop"
+  source={tailRecursiveSum}
+/>
+
+<TraceExample
+  title="Tail-recursive factorial"
+  description="Computes 5! with an accumulator; TCO folds it into a loop"
+  source={tailRecursiveFactorial}
+/>
+
+At level 0, each `sum`/`fact` call is a real invoke/return pair and the
+call stack grows one frame per iteration. At level 2, the recursive
+call becomes a **back-edge**: a single JUMP that ends one iteration and
+begins the next without pushing a frame. The call stack stays flat.
+
+That one JUMP carries three facts at once, composed as sibling keys on a
+single context — the flat form described on the
+[transform context](/spec/program/context/transform) page:
+
+<SchemaExample
+  schema="program/context/transform"
+  href="/spec/program/context/transform"
+  title="TCO back-edge: return + invoke + transform"
+>
+  {`{
+  "return": {
+    "identifier": "sum"
+  },
+  "invoke": {
+    "jump": true,
+    "identifier": "sum",
+    "target": {
+      "pointer": { "location": "code", "offset": "0x33", "length": 1 }
+    }
+  },
+  "transform": ["tailcall"]
+}`}
+</SchemaExample>
+
+The `return` and `invoke` state the source-level facts — the previous
+iteration returned, the next was invoked — and `transform: ["tailcall"]`
+explains how the compiler realized that pair as one JUMP. Because no
+value crosses a frame boundary here, the `return` carries no `data` and
+the `invoke` no `arguments`: the accumulator is threaded through the
+loop directly, and the invoke `target` points at the loop header the
+JUMP re-enters. A debugger that ignores the transform still reads a
+coherent invoke/return sequence; one that understands it can show that
+the call stack isn't really growing, and present the recursion as the
+loop it compiled to.
 
 ## Trace data structure
 

--- a/packages/web/src/schemas.ts
+++ b/packages/web/src/schemas.ts
@@ -228,7 +228,16 @@ const programSchemaIndex: SchemaIndex = {
     href: "/spec/program/context",
   },
 
-  ...["name", "code", "variables", "remark", "pick", "gather", "frame"]
+  ...[
+    "name",
+    "code",
+    "variables",
+    "remark",
+    "pick",
+    "gather",
+    "frame",
+    "transform",
+  ]
     .map((name) => ({
       [`schema:ethdebug/format/program/context/${name}`]: {
         href: `/spec/program/context/${name}`,


### PR DESCRIPTION
Adds two self-tail-recursive BUG programs (accumulator **sum** and **factorial**) and a **Tail-call optimization** section to the tracing page. Both fold under bugc's level-2 optimizer (verified locally: the recursive call terminator is eliminated and replaced with a loop trampoline).

The prose explains how a TCO back-edge JUMP composes `return`, `invoke`, and `transform: ["tailcall"]` as sibling keys on one context (the flat form), and how a debugger reconciles that with the source-level call stack. The example JSON matches the shape #217 emits (return = identifier only, invoke = jump + identifier + code `target`, no `data`/`arguments`, since nothing crosses a frame boundary).

Also registers `program/context/transform` in the web `schemaIndex` — it was missing (`gather` was present), which broke the docs build for #212's transform spec page.

**Known blocker for the live annotation (not this PR):** the `tailCall` metadata the TCO step sets on the back-edge jump is stripped by a later level-2 optimizer pass, so no tailcall context currently reaches the bytecode. Details sent to compiler; tracked under end-to-end verification. This PR is preview-build-driven; the widget will show the annotation once the pipeline + UI (level selector, transform rendering) land.