### PR TITLE
docs: link first frame mention to its spec page

### DIFF
--- a/packages/web/spec/program/context/gather.mdx
+++ b/packages/web/spec/program/context/gather.mdx
@@ -26,7 +26,8 @@ works.
 Reach for `gather` only when two or more facts would collide on
 the same key. The canonical cases are:
 
-- **Multiple `frame`s** — an instruction that maps
+- **Multiple [`frame`](/spec/program/context/frame)s** — an instruction
+  that maps
   simultaneously to an IR step and a source step needs one
   entry per frame, each with its own `code` range.
 - **Multiple `variables` blocks** — when separate pipeline

--- a/packages/web/spec/program/context/transform.mdx
+++ b/packages/web/spec/program/context/transform.mdx
@@ -114,6 +114,7 @@ single JUMP.
 
 Reach for [`gather`](/spec/program/context/gather) only when
 two contexts would collide on the same key — e.g., two
-independent `variables` blocks or two `frame`s from different
+independent `variables` blocks or two
+[`frame`](/spec/program/context/frame)s from different
 pipeline stages. When keys don't collide, the flat form is
 preferred.


### PR DESCRIPTION
Small follow-up to #212. In `transform.mdx` and `gather.mdx`, the first reference to `frame` contexts now links to `/spec/program/context/frame`, matching the existing [`gather`](...) link precedent. Frame is the one composition concept a reader reaching these pages may not have met yet.

First mention only in each file; subsequent bare `frame`s left as-is. Suggested by me, confirmed by architect (PR owner).