### PR TITLE
docs: match TCO example prose to the Opt selector (O0-O3)

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing.mdx
+++ b/packages/web/docs/core-schemas/programs/tracing.mdx
@@ -260,9 +260,10 @@ The two programs below are written so bugc's optimizer folds them. Each
 accumulates its result in an `acc` parameter and hands it to the next
 call in tail position, so no work is left pending on the stack.
 
-Use the optimizer control on each example to switch between level 0
-(no optimization) and level 2 (TCO on), then step through and compare
-the call stack.
+Use the **Opt** selector in the trace drawer to set the optimization
+level. Compile at **O0** (no optimization) and again at **O2**
+(optimizations on, including TCO), then step through and compare the
+call stack. TCO kicks in at **O2**.
 
 <TraceExample
   title="Tail-recursive sum"
@@ -276,8 +277,8 @@ the call stack.
   source={tailRecursiveFactorial}
 />
 
-At level 0, each `sum`/`fact` call is a real invoke/return pair and the
-call stack grows one frame per iteration. At level 2, the recursive
+At **O0**, each `sum`/`fact` call is a real invoke/return pair and the
+call stack grows one frame per iteration. At **O2**, the recursive
 call becomes a **back-edge**: a single JUMP that ends one iteration and
 begins the next without pushing a frame. The call stack stays flat.
 


### PR DESCRIPTION
Follow-up to #219. Updates the tail-call-optimization walkthrough in `tracing.mdx` to reference the tracer drawer's **Opt** optimization-level selector (O0–O3, per ui's landed control), telling readers to compare **O0** with **O2** (TCO kicks in at level 2). Replaces the generic "optimizer control"/toggle wording so the prose matches the control the reader uses.

Text only; no example/JSON changes.