### PR TITLE
web: tracer drawer — opt-level selector, tailcall render, right-column panels

### DIFF
--- a/packages/programs-react/src/utils/mockTrace.test.ts
+++ b/packages/programs-react/src/utils/mockTrace.test.ts
@@ -115,3 +115,76 @@ describe("buildCallStack TCO frame replacement", () => {
     expect(stack[0].isTailCall).toBeFalsy();
   });
 });
+
+// The compiler (bugc #217) emits the TCO back-edge as a
+// single FLAT context object carrying return + invoke +
+// transform keys together (not a gather). This is the
+// actual production shape, so it needs direct coverage.
+describe("flat (production) TCO back-edge shape", () => {
+  const flatBackEdge = {
+    return: { identifier: "sum" },
+    invoke: {
+      jump: true,
+      identifier: "sum",
+      target: { pointer: { location: "code", offset: 0, length: 1 } },
+    },
+    transform: ["tailcall"],
+  };
+
+  it("extracts the tailcall transform from the flat object", () => {
+    expect(extractTransformFromInstruction(instr(0, flatBackEdge))).toEqual([
+      "tailcall",
+    ]);
+  });
+
+  it("marks isTailCall on the flat back-edge", () => {
+    const info = extractCallInfoFromInstruction(instr(0, flatBackEdge));
+    expect(info?.isTailCall).toBe(true);
+  });
+
+  it("replaces the frame in place for a flat back-edge", () => {
+    const trace: TraceStep[] = [
+      { pc: 0, opcode: "JUMPDEST" },
+      { pc: 10, opcode: "JUMP" },
+    ];
+    const program = {
+      instructions: [
+        instr(0, { invoke: { jump: true, identifier: "sum" } }),
+        instr(10, flatBackEdge),
+      ],
+    } as unknown as Program;
+    const pcToInstruction = buildPcToInstructionMap(program);
+
+    const stack = buildCallStack(trace, pcToInstruction, 1);
+    expect(stack).toHaveLength(1);
+    expect(stack[0].identifier).toBe("sum");
+    expect(stack[0].isTailCall).toBe(true);
+    expect(stack[0].callType).toBe("internal");
+  });
+
+  it("loses tail-call handling when the marker is stripped", () => {
+    // Guards the task #10 failure mode: with the transform
+    // marker gone, the flat {return, invoke} back-edge is
+    // treated as a plain invoke — the frame-replacement path
+    // never runs, so no frame is flagged as a tail call and
+    // the widget can no longer render it as a frame reuse.
+    const stripped = {
+      return: { identifier: "sum" },
+      invoke: { jump: true, identifier: "sum" },
+    };
+    const trace: TraceStep[] = [
+      { pc: 0, opcode: "JUMPDEST" },
+      { pc: 10, opcode: "JUMP" },
+    ];
+    const program = {
+      instructions: [
+        instr(0, { invoke: { jump: true, identifier: "sum" } }),
+        instr(10, stripped),
+      ],
+    } as unknown as Program;
+    const pcToInstruction = buildPcToInstructionMap(program);
+
+    const stack = buildCallStack(trace, pcToInstruction, 1);
+    expect(stack.some((f) => f.isTailCall)).toBe(false);
+  });
+});

--- a/packages/web/src/theme/ProgramExample/TraceDrawer.css
+++ b/packages/web/src/theme/ProgramExample/TraceDrawer.css
@@ -208,7 +208,13 @@
 .trace-panels {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  /* Single row that fills the flex height, so the panels
+     absorb vertical space when the drawer is drag-expanded
+     (an `auto` row would size to content and leave dead
+     space below). */
+  grid-template-rows: 1fr;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
   gap: 1px;
   background: var(--ifm-color-emphasis-200);
@@ -216,6 +222,9 @@
 
 .trace-panel {
   background: var(--ifm-background-color);
+  /* min-height:0 lets the grid item shrink so its own
+     overflow scrolls instead of expanding the grid. */
+  min-height: 0;
   overflow: auto;
 }
 

--- a/packages/web/src/theme/ProgramExample/TraceDrawer.css
+++ b/packages/web/src/theme/ProgramExample/TraceDrawer.css
@@ -259,6 +259,26 @@
   border-left: 3px solid var(--ifm-color-danger);
 }
 
+/* Transform / tail-call accent (no ifm purple semantic, so
+   a theme-tolerant purple tint with content-colored text). */
+.call-info-tailcall {
+  background: rgba(130, 80, 223, 0.12);
+  color: var(--ifm-color-content);
+  border-left: 3px solid #8250df;
+}
+
+.call-stack-tailcall {
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  background: rgba(130, 80, 223, 0.15);
+  color: var(--ifm-color-content);
+  border: 1px solid rgba(130, 80, 223, 0.45);
+}
+
 /* Trace panels */
 .trace-panels {
   display: grid;
@@ -310,6 +330,72 @@
   font-size: 14px;
   font-weight: 600;
   color: var(--ifm-color-primary-darkest);
+}
+
+.opcode-gas {
+  margin-left: auto;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--ifm-color-content-secondary);
+}
+
+/* Collapsible right-column sections */
+.trace-section {
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.trace-section-summary {
+  padding: 6px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-content-secondary);
+  background: var(--ifm-background-surface-color);
+  cursor: pointer;
+  user-select: none;
+  list-style-position: inside;
+}
+
+.trace-section-summary:hover {
+  color: var(--ifm-color-content);
+}
+
+/* Transform annotations */
+.transform-list {
+  padding: 6px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.transform-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.transform-tag {
+  flex-shrink: 0;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 600;
+  font-size: 11px;
+  color: var(--ifm-color-content);
+  background: rgba(130, 80, 223, 0.15);
+  border: 1px solid rgba(130, 80, 223, 0.45);
+}
+
+.transform-gloss {
+  color: var(--ifm-color-content-secondary);
+}
+
+.variable-value {
+  font-family: var(--ifm-font-family-monospace);
+  color: var(--ifm-color-content);
+  word-break: break-all;
 }
 
 .current-opcode .opcode-pc {

--- a/packages/web/src/theme/ProgramExample/TraceDrawer.css
+++ b/packages/web/src/theme/ProgramExample/TraceDrawer.css
@@ -25,6 +25,61 @@
   overflow: hidden;
 }
 
+/* Header actions */
+.trace-drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.opt-level-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px 2px 8px;
+  border-radius: 6px;
+  background: var(--ifm-color-emphasis-100);
+}
+
+.opt-level-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ifm-color-content-secondary);
+  margin-right: 2px;
+}
+
+.opt-level-btn {
+  padding: 2px 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-color-content-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--ifm-font-family-monospace);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.opt-level-btn:hover:not(:disabled) {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.opt-level-btn.active {
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: white;
+}
+
+.opt-level-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Header buttons */
 .trace-drawer-btn {
   padding: 6px 14px;

--- a/packages/web/src/theme/ProgramExample/TraceDrawer.tsx
+++ b/packages/web/src/theme/ProgramExample/TraceDrawer.tsx
@@ -25,6 +25,15 @@ import {
 } from "@ethdebug/bugc-react";
 import { Executor, createTraceCollector, type TraceStep } from "@ethdebug/evm";
 import { dereference, Data, type Machine } from "@ethdebug/pointers";
+import {
+  buildCallStack,
+  extractCallInfoFromInstruction,
+  extractTransformFromInstruction,
+  type CallFrame,
+  type CallInfo,
+  type TraceStep as ProgramsTraceStep,
+} from "@ethdebug/programs-react";
+import type { Program } from "@ethdebug/format";
 import { Drawer } from "@theme/Drawer";
 import { useTracePlayground } from "./TracePlaygroundContext";
 
@@ -100,77 +109,52 @@ function TraceDrawerContent(): JSX.Element {
     return extractVariables(instruction.debug.context);
   }, [trace, currentStep, pcToInstruction]);
 
-  // Extract call info from current instruction context
-  const currentCallInfo = useMemo(() => {
-    if (trace.length === 0 || currentStep >= trace.length) {
-      return undefined;
+  // Adapt the bugc instruction map + evm trace to the shared
+  // programs-react call-stack helpers, which read the
+  // ethdebug format shape (instruction.context) and a {pc}
+  // trace. This lets the drawer reuse the same tailcall-aware
+  // buildCallStack as the standalone TraceViewer instead of
+  // duplicating the logic.
+  const formatPcToInstruction = useMemo(() => {
+    const m = new Map<number, Program.Instruction>();
+    for (const [pc, inst] of pcToInstruction) {
+      m.set(pc, {
+        offset: pc,
+        context: inst.debug?.context,
+      } as unknown as Program.Instruction);
     }
+    return m;
+  }, [pcToInstruction]);
 
+  const programsTrace = useMemo<ProgramsTraceStep[]>(
+    () => trace.map((s) => ({ pc: s.pc, opcode: s.opcode })),
+    [trace],
+  );
+
+  const currentInstruction = useMemo(() => {
     const step = trace[currentStep];
-    const instruction = pcToInstruction.get(step.pc);
-    if (!instruction?.debug?.context) return undefined;
+    if (!step) return undefined;
+    return formatPcToInstruction.get(step.pc);
+  }, [trace, currentStep, formatPcToInstruction]);
 
-    return extractCallInfo(instruction.debug.context);
-  }, [trace, currentStep, pcToInstruction]);
+  // Extract call info from current instruction context
+  const currentCallInfo = useMemo<CallInfo | undefined>(() => {
+    if (!currentInstruction) return undefined;
+    return extractCallInfoFromInstruction(currentInstruction);
+  }, [currentInstruction]);
 
-  // Build call stack by scanning invoke/return/revert up to
-  // current step
-  const callStack = useMemo(() => {
-    const frames: Array<{
-      identifier?: string;
-      stepIndex: number;
-      callType?: string;
-      argumentNames?: string[];
-      argumentPointers?: unknown[];
-    }> = [];
+  // Compiler transform tags on the current instruction
+  // (e.g. "tailcall"), for the transform annotations panel.
+  const currentTransforms = useMemo<string[]>(() => {
+    if (!currentInstruction) return [];
+    return extractTransformFromInstruction(currentInstruction);
+  }, [currentInstruction]);
 
-    for (let i = 0; i <= currentStep && i < trace.length; i++) {
-      const step = trace[i];
-      const instruction = pcToInstruction.get(step.pc);
-      if (!instruction?.debug?.context) continue;
-
-      const info = extractCallInfo(instruction.debug.context);
-      if (!info) continue;
-
-      if (info.kind === "invoke") {
-        // The compiler emits invoke on both the caller
-        // JUMP and callee entry JUMPDEST for the same
-        // call. These occur on consecutive trace steps.
-        // Only skip if the top frame matches AND was
-        // pushed on the immediately preceding step —
-        // otherwise this is a new call (e.g. recursion).
-        const top = frames[frames.length - 1];
-        const isDuplicate =
-          top &&
-          top.identifier === info.identifier &&
-          top.callType === info.callType &&
-          top.stepIndex === i - 1;
-        if (isDuplicate) {
-          // Use the callee entry step for resolution —
-          // argument pointers reference stack slots
-          // valid at the JUMPDEST, not the JUMP.
-          // Argument names also live on the callee entry.
-          top.stepIndex = i;
-          top.argumentNames = info.argumentNames ?? top.argumentNames;
-          top.argumentPointers = info.argumentPointers;
-        } else {
-          frames.push({
-            identifier: info.identifier,
-            stepIndex: i,
-            callType: info.callType,
-            argumentNames: info.argumentNames,
-            argumentPointers: info.argumentPointers,
-          });
-        }
-      } else if (info.kind === "return" || info.kind === "revert") {
-        if (frames.length > 0) {
-          frames.pop();
-        }
-      }
-    }
-
-    return frames;
-  }, [trace, currentStep, pcToInstruction]);
+  // Build call stack via the shared, tailcall-aware helper.
+  const callStack = useMemo<CallFrame[]>(
+    () => buildCallStack(programsTrace, formatPcToInstruction, currentStep),
+    [programsTrace, formatPcToInstruction, currentStep],
+  );
 
   // Resolve argument values for call stack frames
   const argCacheRef = useRef<Map<number, ResolvedArg[]>>(new Map());
@@ -244,6 +228,56 @@ function TraceDrawerContent(): JSX.Element {
       cancelled = true;
     };
   }, [callStack, trace, storage]);
+
+  // Resolve the current instruction's variable values by
+  // dereferencing each variable's pointer against the step
+  // state (reuses the same machinery as argument resolution).
+  const [resolvedVarValues, setResolvedVarValues] = useState<
+    Map<string, string>
+  >(new Map());
+
+  useEffect(() => {
+    const step = trace[currentStep];
+    if (!step || currentVariables.length === 0) {
+      setResolvedVarValues(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    const state = traceStepToState(step, storage);
+    const next = new Map<string, string>();
+
+    Promise.all(
+      currentVariables.map(async (v) => {
+        if (!v.pointer) return;
+        try {
+          next.set(v.identifier, await resolvePointer(v.pointer, state));
+        } catch {
+          // leave unresolved
+        }
+      }),
+    ).then(() => {
+      if (!cancelled) setResolvedVarValues(next);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVariables, currentStep, trace, storage]);
+
+  // Gas remaining at the current step plus the delta consumed
+  // reaching it (when the executor reports gas).
+  const gasText = useMemo(() => {
+    const step = trace[currentStep];
+    if (!step || step.gasRemaining === undefined) return "";
+    const rem = step.gasRemaining.toLocaleString();
+    const prev = trace[currentStep - 1];
+    if (prev?.gasRemaining !== undefined) {
+      const delta = prev.gasRemaining - step.gasRemaining;
+      if (delta > 0n) return `gas ${rem} (−${delta.toLocaleString()})`;
+    }
+    return `gas ${rem}`;
+  }, [trace, currentStep]);
 
   // Compile source and run trace in one shot.
   // Takes source directly to avoid stale-state issues.
@@ -571,6 +605,14 @@ function TraceDrawerContent(): JSX.Element {
                       >
                         {frame.identifier || "(anonymous)"}(
                         {formatFrameArgs(frame, resolvedArgs)})
+                        {frame.isTailCall && (
+                          <span
+                            className="call-stack-tailcall"
+                            title="Tail call: frame reused in place (TCO)"
+                          >
+                            ⮌ tail call
+                          </span>
+                        )}
                       </button>
                     </React.Fragment>
                   ))
@@ -579,7 +621,11 @@ function TraceDrawerContent(): JSX.Element {
 
               {currentCallInfo && (
                 <div
-                  className={`call-info-bar call-info-${currentCallInfo.kind}`}
+                  className={`call-info-bar ${
+                    currentCallInfo.isTailCall
+                      ? "call-info-tailcall"
+                      : `call-info-${currentCallInfo.kind}`
+                  }`}
                 >
                   {formatCallBanner(currentCallInfo)}
                 </div>
@@ -603,23 +649,34 @@ function TraceDrawerContent(): JSX.Element {
                         <span className="opcode-pc">
                           @ 0x{currentTraceStep.pc.toString(16)}
                         </span>
+                        {gasText && (
+                          <span className="opcode-gas">{gasText}</span>
+                        )}
                       </div>
 
-                      <div className="panel-header">Stack</div>
-                      <StackDisplay stack={currentTraceStep.stack} />
+                      {currentTransforms.length > 0 && (
+                        <Section title="Transform">
+                          <TransformList transforms={currentTransforms} />
+                        </Section>
+                      )}
+
+                      <Section title="Stack">
+                        <StackDisplay stack={currentTraceStep.stack} />
+                      </Section>
 
                       {currentVariables.length > 0 && (
-                        <>
-                          <div className="panel-header">Variables</div>
-                          <VariablesDisplay variables={currentVariables} />
-                        </>
+                        <Section title="Variables">
+                          <VariablesDisplay
+                            variables={currentVariables}
+                            resolved={resolvedVarValues}
+                          />
+                        </Section>
                       )}
 
                       {Object.keys(storage).length > 0 && (
-                        <>
-                          <div className="panel-header">Storage</div>
+                        <Section title="Storage" defaultOpen={false}>
                           <StorageDisplay storage={storage} />
-                        </>
+                        </Section>
                       )}
                     </>
                   )}
@@ -734,107 +791,93 @@ function formatBigInt(value: bigint): string {
 interface Variable {
   identifier: string;
   type?: string;
+  pointer?: unknown;
 }
 
 interface VariablesDisplayProps {
   variables: Variable[];
+  resolved: Map<string, string>;
 }
 
-function VariablesDisplay({ variables }: VariablesDisplayProps): JSX.Element {
+function VariablesDisplay({
+  variables,
+  resolved,
+}: VariablesDisplayProps): JSX.Element {
   return (
     <div className="variables-list">
-      {variables.map((variable, i) => (
-        <div key={i} className="variable-item">
-          <span className="variable-name">{variable.identifier}</span>
-          {variable.type && (
-            <span className="variable-type">{variable.type}</span>
-          )}
+      {variables.map((variable, i) => {
+        const value = resolved.get(variable.identifier);
+        return (
+          <div key={i} className="variable-item">
+            <span className="variable-name">{variable.identifier}</span>
+            {value !== undefined && (
+              <code className="variable-value">{formatAsDecimal(value)}</code>
+            )}
+            {variable.type && (
+              <span className="variable-type">{variable.type}</span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** One-line glosses for known transform identifiers. */
+const TRANSFORM_GLOSS: Record<string, string> = {
+  tailcall: "tail call — frame reused, no new activation (TCO)",
+  inline: "inlined function body",
+  fold: "constant-folded at compile time",
+  coalesce: "merged read/write sequence",
+};
+
+function TransformList({ transforms }: { transforms: string[] }): JSX.Element {
+  return (
+    <div className="transform-list">
+      {transforms.map((t, i) => (
+        <div key={i} className="transform-item">
+          <span className="transform-tag">{t}</span>
+          <span className="transform-gloss">
+            {TRANSFORM_GLOSS[t] ?? "compiler transform"}
+          </span>
         </div>
       ))}
     </div>
   );
 }
 
+/** A collapsible right-column section. */
+function Section({
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <details className="trace-section" open={defaultOpen}>
+      <summary className="trace-section-summary">{title}</summary>
+      {children}
+    </details>
+  );
+}
+
 /**
  * Info about a call context (invoke/return/revert).
  */
-interface CallInfoResult {
-  kind: "invoke" | "return" | "revert";
-  identifier?: string;
-  callType?: string;
-  argumentNames?: string[];
-  argumentPointers?: unknown[];
-}
-
-/**
- * Extract call info from an ethdebug format context object.
- */
-function extractCallInfo(context: unknown): CallInfoResult | undefined {
-  if (!context || typeof context !== "object") {
-    return undefined;
-  }
-
-  const ctx = context as Record<string, unknown>;
-
-  if ("invoke" in ctx && ctx.invoke) {
-    const inv = ctx.invoke as Record<string, unknown>;
-    let callType: string | undefined;
-    if ("jump" in inv) callType = "internal";
-    else if ("message" in inv) callType = "external";
-    else if ("create" in inv) callType = "create";
-
-    const argInfo = extractArgInfoFromInvoke(inv);
-    return {
-      kind: "invoke",
-      identifier: inv.identifier as string | undefined,
-      callType,
-      argumentNames: argInfo?.names,
-      argumentPointers: argInfo?.pointers,
-    };
-  }
-
-  if ("return" in ctx && ctx.return) {
-    const ret = ctx.return as Record<string, unknown>;
-    return {
-      kind: "return",
-      identifier: ret.identifier as string | undefined,
-    };
-  }
-
-  if ("revert" in ctx && ctx.revert) {
-    const rev = ctx.revert as Record<string, unknown>;
-    return {
-      kind: "revert",
-      identifier: rev.identifier as string | undefined,
-    };
-  }
-
-  // Walk gather/pick
-  if ("gather" in ctx && Array.isArray(ctx.gather)) {
-    for (const sub of ctx.gather) {
-      const info = extractCallInfo(sub);
-      if (info) return info;
-    }
-  }
-
-  if ("pick" in ctx && Array.isArray(ctx.pick)) {
-    for (const sub of ctx.pick) {
-      const info = extractCallInfo(sub);
-      if (info) return info;
-    }
-  }
-
-  return undefined;
-}
-
 /**
  * Format a call info banner string.
  */
-function formatCallBanner(info: CallInfoResult): string {
+function formatCallBanner(info: CallInfo): string {
   const name = info.identifier || "(anonymous)";
   const params = info.argumentNames
     ? `(${info.argumentNames.join(", ")})`
     : "()";
+  if (info.isTailCall) {
+    return `Tail call: ${name} (frame reused)`;
+  }
   switch (info.kind) {
     case "invoke": {
       const prefix = info.callType === "create" ? "Creating" : "Calling";
@@ -845,38 +888,6 @@ function formatCallBanner(info: CallInfoResult): string {
     case "revert":
       return `Reverted in ${name}()`;
   }
-}
-
-function extractArgInfoFromInvoke(
-  inv: Record<string, unknown>,
-): { names?: string[]; pointers?: unknown[] } | undefined {
-  const args = inv.arguments as Record<string, unknown> | undefined;
-  if (!args) return undefined;
-
-  const pointer = args.pointer as Record<string, unknown> | undefined;
-  if (!pointer) return undefined;
-
-  const group = pointer.group as Array<Record<string, unknown>> | undefined;
-  if (!Array.isArray(group)) return undefined;
-
-  const names: string[] = [];
-  const pointers: unknown[] = [];
-  let hasAnyName = false;
-  for (const entry of group) {
-    const name = entry.name as string | undefined;
-    if (name) {
-      names.push(name);
-      hasAnyName = true;
-    } else {
-      names.push("_");
-    }
-    pointers.push(entry);
-  }
-
-  return {
-    names: hasAnyName ? names : undefined,
-    pointers,
-  };
 }
 
 /**
@@ -898,6 +909,7 @@ function extractVariables(context: unknown): Variable[] {
         variables.push({
           identifier: String(variable.identifier),
           type: variable.type ? formatType(variable.type) : undefined,
+          pointer: variable.pointer,
         });
       }
     }

--- a/packages/web/src/theme/ProgramExample/TraceDrawer.tsx
+++ b/packages/web/src/theme/ProgramExample/TraceDrawer.tsx
@@ -51,6 +51,16 @@ interface CompileResult {
   bytecode?: BytecodeOutput;
 }
 
+/** bugc optimizer levels the tracer can compile at. */
+type OptLevel = 0 | 1 | 2 | 3;
+const OPT_LEVELS: readonly OptLevel[] = [0, 1, 2, 3];
+const OPT_LEVEL_TITLES: Record<OptLevel, string> = {
+  0: "No optimization",
+  1: "Level 1 — constant folding, propagation, dead-code elimination",
+  2: "Level 2 — adds CSE, tail-call optimization, jump optimization",
+  3: "Level 3 — adds block/return/read-write merging",
+};
+
 function TraceDrawerContent(): JSX.Element {
   const { example, isOpen, toggleDrawer, closeDrawer, setSource } =
     useTracePlayground();
@@ -70,8 +80,8 @@ function TraceDrawerContent(): JSX.Element {
   // annotation on TCO back-edges) appear. A ref mirrors it
   // so the example-load effect can read the current value
   // without re-running when only the level changes.
-  const [optimizerLevel, setOptimizerLevel] = useState<0 | 2>(0);
-  const optimizerLevelRef = useRef<0 | 2>(optimizerLevel);
+  const [optimizerLevel, setOptimizerLevel] = useState<OptLevel>(0);
+  const optimizerLevelRef = useRef<OptLevel>(optimizerLevel);
   optimizerLevelRef.current = optimizerLevel;
 
   // Build PC -> instruction map for source highlighting
@@ -282,7 +292,7 @@ function TraceDrawerContent(): JSX.Element {
   // Compile source and run trace in one shot.
   // Takes source directly to avoid stale-state issues.
   const compileAndTrace = useCallback(
-    async (sourceCode: string, level: 0 | 2) => {
+    async (sourceCode: string, level: OptLevel) => {
       setIsCompiling(true);
       setCompileResult(null);
       setTrace([]);
@@ -386,7 +396,7 @@ function TraceDrawerContent(): JSX.Element {
   }, [source, compileAndTrace, optimizerLevel]);
 
   const handleLevelChange = useCallback(
-    (level: 0 | 2) => {
+    (level: OptLevel) => {
       if (level === optimizerLevel) return;
       setOptimizerLevel(level);
       compileAndTrace(source, level);
@@ -456,26 +466,21 @@ function TraceDrawerContent(): JSX.Element {
         aria-label="Optimizer level"
       >
         <span className="opt-level-label">Opt</span>
-        <button
-          className={`opt-level-btn ${optimizerLevel === 0 ? "active" : ""}`}
-          onClick={() => handleLevelChange(0)}
-          disabled={isBusy}
-          type="button"
-          title="Compile without optimizations"
-          aria-pressed={optimizerLevel === 0}
-        >
-          O0
-        </button>
-        <button
-          className={`opt-level-btn ${optimizerLevel === 2 ? "active" : ""}`}
-          onClick={() => handleLevelChange(2)}
-          disabled={isBusy}
-          type="button"
-          title="Compile with optimizations (level 2 — enables TCO)"
-          aria-pressed={optimizerLevel === 2}
-        >
-          O2
-        </button>
+        {OPT_LEVELS.map((level) => (
+          <button
+            key={level}
+            className={`opt-level-btn ${
+              optimizerLevel === level ? "active" : ""
+            }`}
+            onClick={() => handleLevelChange(level)}
+            disabled={isBusy}
+            type="button"
+            title={OPT_LEVEL_TITLES[level]}
+            aria-pressed={optimizerLevel === level}
+          >
+            O{level}
+          </button>
+        ))}
       </div>
       <button
         className="trace-drawer-btn trace-btn"

--- a/packages/web/src/theme/ProgramExample/TraceDrawer.tsx
+++ b/packages/web/src/theme/ProgramExample/TraceDrawer.tsx
@@ -56,6 +56,14 @@ function TraceDrawerContent(): JSX.Element {
   const [isTracing, setIsTracing] = useState(false);
   const [traceError, setTraceError] = useState<string | null>(null);
   const [storage, setStorage] = useState<Record<string, string>>({});
+  // Optimizer level the tracer compiles at. Readers flip
+  // 0 ↔ 2 to watch optimizer transforms (e.g. the tailcall
+  // annotation on TCO back-edges) appear. A ref mirrors it
+  // so the example-load effect can read the current value
+  // without re-running when only the level changes.
+  const [optimizerLevel, setOptimizerLevel] = useState<0 | 2>(0);
+  const optimizerLevelRef = useRef<0 | 2>(optimizerLevel);
+  optimizerLevelRef.current = optimizerLevel;
 
   // Build PC -> instruction map for source highlighting
   const pcToInstruction = useMemo(() => {
@@ -239,92 +247,95 @@ function TraceDrawerContent(): JSX.Element {
 
   // Compile source and run trace in one shot.
   // Takes source directly to avoid stale-state issues.
-  const compileAndTrace = useCallback(async (sourceCode: string) => {
-    setIsCompiling(true);
-    setCompileResult(null);
-    setTrace([]);
-    setCurrentStep(0);
-    setTraceError(null);
-    setStorage({});
+  const compileAndTrace = useCallback(
+    async (sourceCode: string, level: 0 | 2) => {
+      setIsCompiling(true);
+      setCompileResult(null);
+      setTrace([]);
+      setCurrentStep(0);
+      setTraceError(null);
+      setStorage({});
 
-    let bytecode: BytecodeOutput | undefined;
+      let bytecode: BytecodeOutput | undefined;
 
-    try {
-      const result = await bugCompile({
-        to: "bytecode",
-        source: sourceCode,
-        optimizer: { level: 0 },
-      });
+      try {
+        const result = await bugCompile({
+          to: "bytecode",
+          source: sourceCode,
+          optimizer: { level },
+        });
 
-      if (!result.success) {
-        const errors = result.messages[Severity.Error] || [];
+        if (!result.success) {
+          const errors = result.messages[Severity.Error] || [];
+          setCompileResult({
+            success: false,
+            error: errors[0]?.message || "Compilation failed",
+          });
+          return;
+        }
+
+        bytecode = {
+          runtime: result.value.bytecode.runtime,
+          create: result.value.bytecode.create,
+          runtimeInstructions: result.value.bytecode.runtimeInstructions,
+          createInstructions: result.value.bytecode.createInstructions,
+        };
+
+        setCompileResult({ success: true, bytecode });
+      } catch (e) {
         setCompileResult({
           success: false,
-          error: errors[0]?.message || "Compilation failed",
+          error: e instanceof Error ? e.message : String(e),
         });
         return;
+      } finally {
+        setIsCompiling(false);
       }
 
-      bytecode = {
-        runtime: result.value.bytecode.runtime,
-        create: result.value.bytecode.create,
-        runtimeInstructions: result.value.bytecode.runtimeInstructions,
-        createInstructions: result.value.bytecode.createInstructions,
-      };
+      if (!bytecode) return;
 
-      setCompileResult({ success: true, bytecode });
-    } catch (e) {
-      setCompileResult({
-        success: false,
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return;
-    } finally {
-      setIsCompiling(false);
-    }
+      setIsTracing(true);
 
-    if (!bytecode) return;
+      try {
+        const executor = new Executor();
 
-    setIsTracing(true);
-
-    try {
-      const executor = new Executor();
-
-      if (bytecode.create) {
-        const createHex = Array.from(bytecode.create)
-          .map((b) => b.toString(16).padStart(2, "0"))
-          .join("");
-        await executor.deploy(createHex);
-      }
-
-      const [handler, getTrace] = createTraceCollector();
-      await executor.execute({}, handler);
-
-      const collectedTrace = getTrace();
-      setTrace(collectedTrace.steps);
-      setCurrentStep(0);
-
-      const storageEntries: Record<string, string> = {};
-      for (let i = 0n; i < 16n; i++) {
-        const value = await executor.getStorage(i);
-        if (value !== 0n) {
-          const slot = `0x${i.toString(16).padStart(2, "0")}`;
-          storageEntries[slot] = `0x${value.toString(16).padStart(64, "0")}`;
+        if (bytecode.create) {
+          const createHex = Array.from(bytecode.create)
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("");
+          await executor.deploy(createHex);
         }
+
+        const [handler, getTrace] = createTraceCollector();
+        await executor.execute({}, handler);
+
+        const collectedTrace = getTrace();
+        setTrace(collectedTrace.steps);
+        setCurrentStep(0);
+
+        const storageEntries: Record<string, string> = {};
+        for (let i = 0n; i < 16n; i++) {
+          const value = await executor.getStorage(i);
+          if (value !== 0n) {
+            const slot = `0x${i.toString(16).padStart(2, "0")}`;
+            storageEntries[slot] = `0x${value.toString(16).padStart(64, "0")}`;
+          }
+        }
+        setStorage(storageEntries);
+      } catch (e) {
+        setTraceError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setIsTracing(false);
       }
-      setStorage(storageEntries);
-    } catch (e) {
-      setTraceError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setIsTracing(false);
-    }
-  }, []);
+    },
+    [],
+  );
 
   // Auto compile+trace when a new example is loaded
   useEffect(() => {
     if (example?.source) {
       setLocalSource(example.source);
-      compileAndTrace(example.source);
+      compileAndTrace(example.source, optimizerLevelRef.current);
     }
   }, [example, compileAndTrace]);
 
@@ -337,8 +348,17 @@ function TraceDrawerContent(): JSX.Element {
   );
 
   const handleCompileAndTrace = useCallback(() => {
-    compileAndTrace(source);
-  }, [source, compileAndTrace]);
+    compileAndTrace(source, optimizerLevel);
+  }, [source, compileAndTrace, optimizerLevel]);
+
+  const handleLevelChange = useCallback(
+    (level: 0 | 2) => {
+      if (level === optimizerLevel) return;
+      setOptimizerLevel(level);
+      compileAndTrace(source, level);
+    },
+    [source, compileAndTrace, optimizerLevel],
+  );
 
   const stepForward = () => {
     setCurrentStep((prev) => Math.min(prev + 1, trace.length - 1));
@@ -395,18 +415,47 @@ function TraceDrawerContent(): JSX.Element {
   const isBusy = isCompiling || isTracing;
 
   const headerActions = (
-    <button
-      className="trace-drawer-btn trace-btn"
-      onClick={handleCompileAndTrace}
-      disabled={isBusy || !source.trim()}
-      type="button"
-    >
-      {isCompiling
-        ? "Compiling..."
-        : isTracing
-          ? "Running..."
-          : "Compile & Run"}
-    </button>
+    <div className="trace-drawer-actions">
+      <div
+        className="opt-level-toggle"
+        role="group"
+        aria-label="Optimizer level"
+      >
+        <span className="opt-level-label">Opt</span>
+        <button
+          className={`opt-level-btn ${optimizerLevel === 0 ? "active" : ""}`}
+          onClick={() => handleLevelChange(0)}
+          disabled={isBusy}
+          type="button"
+          title="Compile without optimizations"
+          aria-pressed={optimizerLevel === 0}
+        >
+          O0
+        </button>
+        <button
+          className={`opt-level-btn ${optimizerLevel === 2 ? "active" : ""}`}
+          onClick={() => handleLevelChange(2)}
+          disabled={isBusy}
+          type="button"
+          title="Compile with optimizations (level 2 — enables TCO)"
+          aria-pressed={optimizerLevel === 2}
+        >
+          O2
+        </button>
+      </div>
+      <button
+        className="trace-drawer-btn trace-btn"
+        onClick={handleCompileAndTrace}
+        disabled={isBusy || !source.trim()}
+        type="button"
+      >
+        {isCompiling
+          ? "Compiling..."
+          : isTracing
+            ? "Running..."
+            : "Compile & Run"}
+      </button>
+    </div>
   );
 
   return (


### PR DESCRIPTION
Package-level (docs `TraceDrawer` widget + programs-react test coverage). No spec/schema changes. Coordinated pass on `TraceDrawer.tsx` covering tasks #3/#6/#9/#11.

## Changes
- **#9 layout fix** — the opcodes/state panels sat in a `flex:1` grid whose row was content-sized, so drag-expanding the drawer left dead space. Explicit `1fr` row + `min-height:0` so both panels absorb the added height and scroll internally.
- **#6 optimizer-level selector** — O0/O2 toggle in the drawer header; `compileAndTrace` now takes the level and recompiles+retraces on toggle. Lets readers flip to O2 and watch optimizer transforms (the tailcall annotation) appear.
- **#3 dedupe + tailcall render** — replaced the drawer's inline call-stack builder and local `extractCallInfo` with the shared, tailcall-aware `buildCallStack`/`extractCallInfoFromInstruction`/`extractTransformFromInstruction` from `@ethdebug/programs-react` (#218), via a thin adapter (bugc `.debug.context` → ethdebug format shape). Gives the docs widget the TCO frame-replacement fix. Renders the tail-call chip on the reused call-stack frame and a tail-call banner variant.
- **#9 right column (gnidan's picks 1/2/4)** — resolved variable values (`name: value` via pointer resolution), gas remaining + per-step delta, and a transform annotations panel with per-tag glosses. Sections are now collapsible. (Held: full storage, call detail, memory.)
- **#11 flat-shape tests** — cover the production flat TCO back-edge shape (#217 emits `{return, invoke, transform}` on one object; tests previously only used the gather shape), plus a guard for the marker-stripped (#10) failure mode.

## Verify
- `yarn build` clean; `build-web` (docusaurus) compiles successfully; programs-react suite 35 passing; eslint clean.
- End-to-end (#4): with #10 fixed, flipping a self-tail-recursive example (#7) to O2 should surface the tailcall chip/panel — best confirmed on the deploy-preview.

Selector labels are "O0"/"O2" (writer #219 mirroring); open to "Level 0/2" if preferred.