### PR TITLE
bugc: preserve function loc/sourceId through optimizer

### DIFF
--- a/packages/bugc/src/evmgen/optimizer-contexts.test.ts
+++ b/packages/bugc/src/evmgen/optimizer-contexts.test.ts
@@ -532,3 +532,65 @@ code { r = count(0, 5); }`;
     }
   });
 });
+
+/**
+ * Count invoke/return contexts that carry a `declaration`
+ * (source id + range for the called/returning function's
+ * declaration). Walks gather wrappers and flat
+ * multi-discriminator contexts.
+ */
+function countDeclarations(program: Format.Program): {
+  invoke: number;
+  return: number;
+} {
+  let invoke = 0;
+  let ret = 0;
+  for (const instr of program.instructions) {
+    if (!instr.context) continue;
+    for (const leaf of unwrapLeaves(instr.context)) {
+      if (Context.isInvoke(leaf) && leaf.invoke.declaration) invoke += 1;
+      if (Context.isReturn(leaf) && leaf.return.declaration) ret += 1;
+    }
+  }
+  return { invoke, return: ret };
+}
+
+/**
+ * Regression: the optimizer must preserve each function's
+ * `loc`/`sourceId` so evmgen can emit `declaration` source
+ * ranges on invoke/return contexts. cloneFunction used to
+ * drop these fields, so every declaration vanished from
+ * optimization level 1 upward.
+ */
+describe("optimizer preserves function declaration info", () => {
+  const source = `name Recur;
+
+define {
+  function count(n: uint256, target: uint256) -> uint256 {
+    if (n < target) { return count(n + 1, target); }
+    else { return n; }
+  };
+}
+
+storage { [0] r: uint256; }
+create { r = 0; }
+code { r = count(0, 5); }`;
+
+  it("carries declarations at level 0 (baseline)", async () => {
+    const program = await compileAt(source, 0);
+    const decls = countDeclarations(program);
+    expect(decls.invoke).toBeGreaterThan(0);
+    expect(decls.return).toBeGreaterThan(0);
+  });
+
+  for (const level of [1, 2, 3] as const) {
+    it(`preserves declarations through optimization at level ${level}`, async () => {
+      const program = await compileAt(source, level);
+      const decls = countDeclarations(program);
+      // The optimizer must not strip function loc/sourceId:
+      // invoke/return contexts still carry declaration ranges.
+      expect(decls.invoke).toBeGreaterThan(0);
+      expect(decls.return).toBeGreaterThan(0);
+    });
+  }
+});

--- a/packages/bugc/src/optimizer/optimizer.ts
+++ b/packages/bugc/src/optimizer/optimizer.ts
@@ -230,6 +230,12 @@ export abstract class BaseOptimizationStep implements OptimizationStep {
       parameters: [...func.parameters],
       entry: func.entry,
       blocks: clonedBlocks,
+      // Preserve declaration source info so evmgen can emit
+      // `declaration` ranges on invoke/return contexts.
+      // Dropping these here erased all declarations from
+      // optimization level 1 upward.
+      ...(func.loc ? { loc: func.loc } : {}),
+      ...(func.sourceId !== undefined ? { sourceId: func.sourceId } : {}),
     };
   }
 


### PR DESCRIPTION
The optimizer's `cloneFunction` dropped the optional `Ir.Function.loc` and `sourceId` fields, returning only `{ name, parameters, entry, blocks }`. Because the first optimization pass clones the module, every function lost its declaration source info from optimization level 1 upward.

evmgen gates `declaration` emission on `func.loc && func.sourceId`, so all invoke/return contexts lost their declaration source ranges at optimized levels.

## Evidence (widget path: `bytecode.runtimeInstructions`)
Before:
```
L0 invoke 3/3 declared; return 2/2 declared
L1 invoke 0/3 declared; return 0/2 declared
L2 invoke 0/3 declared; return 0/2 declared
```
After:
```
L0..L3 invoke 3/3 declared; return 2/2 declared
```

## Fix
Copy `loc`/`sourceId` in `cloneFunction`'s return so declarations survive optimization. This restores declaration source ranges on invoke/return (including the tailcall back-edge) at every optimized level — the levels where the docs demo runs.

## Changes
- `optimizer/optimizer.ts` — `cloneFunction` preserves `loc`/`sourceId`.
- `evmgen/optimizer-contexts.test.ts` — regression test asserting invoke/return contexts still carry `declaration` at levels 1, 2, 3 (with a level-0 baseline).

## Verification
- `yarn build` + full bugc suite green (410 passed, 22 pre-existing skips).
- Drove the widget-path compile of a recursive program at levels 0-3: all now report full declaration coverage.
