### PR TITLE
bugc: emit coalesce transform on read-write merging

### DIFF
--- a/packages/bugc/src/evmgen/transform-contexts.test.ts
+++ b/packages/bugc/src/evmgen/transform-contexts.test.ts
@@ -86,3 +86,29 @@ code { r = (2 + 3) * (4 * 5); }`;
     });
   }
 });
+
+describe("optimizer emits coalesce transform contexts", () => {
+  // Two adjacent packed writes of a runtime value to one storage
+  // slot; read/write merging (level 3) packs them with SHL/OR into
+  // a single word write.
+  const source = `name Coalesce;
+
+define { struct S { a: uint128; b: uint128; }; }
+storage { [0] s: S; [1] src: uint256; }
+create {}
+code { let v = src; s.a = v; s.b = v; }`;
+
+  for (const level of [0, 1, 2] as const) {
+    it(`emits no coalesce transform at level ${level}`, async () => {
+      const bc = await compileBytecode(source, level);
+      expect(countTransform(bc.runtimeInstructions, "coalesce")).toBe(0);
+    });
+  }
+
+  it("emits coalesce transform at level 3", async () => {
+    const bc = await compileBytecode(source, 3);
+    expect(countTransform(bc.runtimeInstructions, "coalesce")).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/packages/bugc/src/optimizer/steps/read-write-merging.ts
+++ b/packages/bugc/src/optimizer/steps/read-write-merging.ts
@@ -368,6 +368,18 @@ export class ReadWriteMergingStep extends BaseOptimizationStep {
       reason: `Merged ${writes.length} writes to same location`,
     });
 
+    // Mark every instruction produced by the merge with
+    // transform:["coalesce"] so debuggers can show the SHL/OR
+    // field-packing sequence as compiler-synthesized rather than
+    // source the user wrote. Appends to any existing transform
+    // array (e.g. a folded packed value → ["fold","coalesce"]).
+    for (const inst of instructions) {
+      inst.operationDebug = Ir.Utils.addTransform(
+        inst.operationDebug,
+        "coalesce",
+      );
+    }
+
     return instructions;
   }
 


### PR DESCRIPTION
Emits `transform: ["coalesce"]` on the SHL/OR field-packing sequence produced by `ReadWriteMerging` (L3), so the tracer widget lights up O3 — a debugger can show a packed-storage write is compiler-synthesized rather than source the user wrote. Completes the emitted-transform set (fold #225 / tailcall #217 / coalesce; `inline` pending the #16 pass).

## Approach
Every instruction the merge produces (shifts, ORs, and the merged write) routes its debug through the shared `Ir.Utils.addTransform` helper (from #225), which appends `coalesce` to any existing `transform` array — so a folded value packed into a word composes as `["fold","coalesce"]`.

Per #212, `coalesce` = read-write (SHL/OR) packing specifically. The CFG-merging passes (`block-merging`, `return-merging`) are intentionally left unmarked for v1 (team-lead + architect agreed; no `merge` id yet).

## Evidence (widget path, `runtimeInstructions`)
```
L0/L1/L2  coalesce-marked instructions: 0
L3        coalesce-marked instructions: >0  (SHL/OR packing seq)
```

## Changes
- `optimizer/steps/read-write-merging.ts` — mark merged instructions via `addTransform`.
- `evmgen/transform-contexts.test.ts` — end-to-end test: coalesce present at L3, absent at L0-2.

## Verification
- `yarn build` + full bugc suite green (418 passed, 22 pre-existing skips).
