### PR TITLE
format: migrate type guards from instanceof Array to Array.isArray

### DIFF
--- a/packages/format/src/types/materials/index.ts
+++ b/packages/format/src/types/materials/index.ts
@@ -74,7 +74,7 @@ export namespace Materials {
     "version" in value.compiler &&
     typeof value.compiler.version === "string" &&
     "sources" in value &&
-    value.sources instanceof Array &&
+    Array.isArray(value.sources) &&
     value.sources.every(isSource);
 
   export interface Source {

--- a/packages/format/src/types/pointer/pointer.ts
+++ b/packages/format/src/types/pointer/pointer.ts
@@ -128,7 +128,7 @@ export namespace Pointer {
       typeof value === "object" &&
       Object.keys(value).length === 1 &&
       "group" in value &&
-      value.group instanceof Array &&
+      Array.isArray(value.group) &&
       value.group.length >= 1 &&
       value.group.every(isPointer);
 
@@ -290,7 +290,7 @@ export namespace Pointer {
 
     export type Operands = Expression[];
     export const isOperands = (value: unknown): value is Expression[] =>
-      value instanceof Array && value.every(isExpression);
+      Array.isArray(value) && value.every(isExpression);
 
     export namespace Arithmetic {
       export type Operation =
@@ -472,7 +472,7 @@ export namespace Pointer {
     typeof value === "object" &&
     Object.keys(value).length === 2 &&
     "expect" in value &&
-    value.expect instanceof Array &&
+    Array.isArray(value.expect) &&
     value.expect.every(isIdentifier) &&
     "for" in value &&
     isPointer(value.for);

--- a/packages/format/src/types/program/context.ts
+++ b/packages/format/src/types/program/context.ts
@@ -45,7 +45,7 @@ export namespace Context {
     typeof value === "object" &&
     !!value &&
     "variables" in value &&
-    value.variables instanceof Array &&
+    Array.isArray(value.variables) &&
     value.variables.length > 0 &&
     value.variables.every(Variables.isVariable);
 

--- a/packages/format/src/types/program/instruction.ts
+++ b/packages/format/src/types/program/instruction.ts
@@ -28,6 +28,5 @@ export namespace Instruction {
     "mnemonic" in value &&
     typeof value.mnemonic === "string" &&
     (!("arguments" in value) ||
-      (value.arguments instanceof Array &&
-        value.arguments.every(Data.isValue)));
+      (Array.isArray(value.arguments) && value.arguments.every(Data.isValue)));
 }

--- a/packages/format/src/types/program/program.ts
+++ b/packages/format/src/types/program/program.ts
@@ -23,7 +23,7 @@ export const isProgram = (value: unknown): value is Program =>
   "environment" in value &&
   Program.isEnvironment(value.environment) &&
   "instructions" in value &&
-  value.instructions instanceof Array &&
+  Array.isArray(value.instructions) &&
   value.instructions.every(Program.isInstruction) &&
   (!("compilation" in value) ||
     Materials.isReference<Materials.Compilation>(value.compilation)) &&

--- a/packages/format/src/types/type/base.ts
+++ b/packages/format/src/types/type/base.ts
@@ -36,7 +36,7 @@ export const isComplex = (value: unknown): value is Complex =>
   "contains" in value &&
   !!value.contains &&
   (isWrapper(value.contains) ||
-    (value.contains instanceof Array && value.contains.every(isWrapper)) ||
+    (Array.isArray(value.contains) && value.contains.every(isWrapper)) ||
     (typeof value.contains === "object" &&
       Object.values(value.contains).every(isWrapper)));
 

--- a/packages/format/src/types/type/index.ts
+++ b/packages/format/src/types/type/index.ts
@@ -27,8 +27,7 @@ export namespace Type {
     "class" in value &&
     (!("contains" in value) ||
       Type.isWrapper(value.contains) ||
-      (value.contains instanceof Array &&
-        value.contains.every(Type.isWrapper)) ||
+      (Array.isArray(value.contains) && value.contains.every(Type.isWrapper)) ||
       (typeof value.contains === "object" &&
         Object.values(value.contains).every(Type.isWrapper)));
 
@@ -262,7 +261,7 @@ export namespace Type {
       mayHaveClass(value, "elementary") &&
       hasKind(value, "enum") &&
       "values" in value &&
-      value.values instanceof Array &&
+      Array.isArray(value.values) &&
       (!("definition" in value) || isDefinition(value.definition));
   }
 
@@ -330,7 +329,7 @@ export namespace Type {
       mayHaveClass(value, "complex") &&
       hasKind(value, "tuple") &&
       "contains" in value &&
-      value.contains instanceof Array &&
+      Array.isArray(value.contains) &&
       value.contains.every(
         (element) =>
           isWrapper(element) &&
@@ -386,7 +385,7 @@ export namespace Type {
       mayHaveClass(value, "complex") &&
       hasKind(value, "struct") &&
       "contains" in value &&
-      value.contains instanceof Array &&
+      Array.isArray(value.contains) &&
       value.contains.every(
         (field) =>
           isWrapper(field) &&


### PR DESCRIPTION
Consistency follow-up (task #8), surfaced by the #212 review.

`Array.isArray` is the cross-realm-safe form and was already used by the
newer context guards (`isPick`, `isGather`) and `isTransform` on the
transform-context branch. This migrates the remaining 12 `x instanceof
Array` sites across the `packages/format` type guards
(type/pointer/materials/program/context) up to match, rather than
leaving inconsistent siblings behind.

Scope note: the task originally named just `isVariables`/`isPick`, but on
main `isPick`/`isGather` were already migrated — only `isVariables`
lagged. Since the rationale (cross-realm safety) applies uniformly and
the edit is identical, I swept all 12 sites in one pass.

Behavior-preserving; no test changes needed. Full suite green (983
passed), build/lint/format all clean.