### PR TITLE
docs: add inlineDemo tracing example (inline showcase)

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing-examples.ts
+++ b/packages/web/docs/core-schemas/programs/tracing-examples.ts
@@ -138,3 +138,27 @@ create {
 code {
   result = fact(5, 1);
 }`;
+
+export const inlineDemo = `name InlineDemo;
+
+define {
+  function square(x: uint256) -> uint256 {
+    return x * x;
+  };
+}
+
+storage {
+  [0] a: uint256;
+  [1] b: uint256;
+  [2] sumOfSquares: uint256;
+}
+
+create {
+  a = 3;
+  b = 4;
+  sumOfSquares = 0;
+}
+
+code {
+  sumOfSquares = square(a) + square(b);
+}`;


### PR DESCRIPTION
Adds the `inlineDemo` tracing example — a dedicated showcase for the
`inline` transform, the way `tailRecursiveSum`/`tailRecursiveFactorial`
showcase `tailcall`.

## The program
A leaf helper `square(x) -> x * x` called from **two sites**:

```
sumOfSquares = square(a) + square(b);   // a = 3, b = 4
```

Args are **storage reads** (`a`, `b`), not constants — so L1 fold can't
collapse the inlined bodies, keeping the two virtual activations visible
in the tracer at O2/O3.

## Verified against bugc (this branch)
- Runtime result correct at O0–O3: `3^2 + 4^2 = 25`.
- Inline marks: **0 at O0/O1**, **both sites inlined at O2** (108 -> 50
  runtime instructions) and O3.
- Virtual invoke (no `target`) / return contexts emitted per the #229
  contract.

## Scope of this PR
Data only — the `inlineDemo` export. Prose + the `<TraceExample>` block
in `tracing.mdx` will follow from writer/docs (coordinating placement
with the #227 Explore/trace-playground reorg).
