### PR TITLE
format: clarify inline activation reconstruction (push/pop vs membership)

### DIFF
--- a/packages/web/spec/program/context/function/invoke.mdx
+++ b/packages/web/spec/program/context/function/invoke.mdx
@@ -125,7 +125,23 @@ uniform whether or not the call was inlined:
 
 - **Push** an activation when an `invoke` context is encountered
   and **pop** it when the matching `return` context is
-  encountered, in trace order.
+  encountered, in trace order. The `invoke` opens the activation
+  inclusive of its instruction; the `return` closes it after its
+  instruction, so the instruction bearing `return` is still inside
+  the activation.
+
+Because push/pop is driven by where the `invoke` and `return`
+contexts sit, a compiler must emit them as a **bracket**: the
+`invoke` on the first instruction of the body and the `return` on
+its last. A compiler must **not** duplicate `invoke` or `return`
+across a body's interior instructions — repeating them would push
+or pop spurious activations. The sole exception is a body that
+compiles to a **single instruction**, whose entry and exit
+coincide: that one instruction legitimately carries both `invoke`
+and `return`, and a debugger processes them in order (push, then
+pop). This bracket rule is what keeps the guarantee below —
+that a debugger ignoring `transform` still sees a coherent
+`invoke`/`return` pair — true for inlined calls.
 
 An inlined callee therefore appears on the call stack exactly as a
 non-inlined one does. Two kinds of activation differ only in how
@@ -147,6 +163,12 @@ transform marker — **not** by whether `target` is present:
 
 ### Activation membership
 
+Push/pop and membership answer two different questions. Push/pop
+(above) determines **when** a virtual activation is open — its
+lifetime on the call stack. Membership determines **which** open
+activation a given instruction belongs to. The two are
+independent, and a debugger uses both.
+
 An instruction belongs to the innermost open virtual activation if
 and only if its context carries an `inline` identifier in its
 transform list — so composed markers such as `["inline", "fold"]`
@@ -157,6 +179,14 @@ per-instruction from this marker, **not** from instruction ranges:
 optimization passes may relocate or interleave an inlined body, so
 a positional "everything between the invoke and the return" rule
 would be unsound.
+
+This is why membership is separate from lifetime. An activation
+opened by an `invoke` stays open until its `return`, even across
+instructions that are **not** its members — for example, caller
+code an optimizer interleaved into the body's trace span. Such a
+non-member instruction (no `inline` marker for that depth) is
+attributed to the enclosing activation, not the inlined one, even
+while the virtual activation remains on the stack.
 
 ### Identity and values
 


### PR DESCRIPTION
Amends the `invoke` spec's "Reconstructing activations" section to close an ambiguity that #230's inline pass exposed end-to-end. This is a **spec-wording change only — no schema change.**

## Why
ui's verification of #230 found the docs tracer mis-renders inline virtual activations (call stack never pops; phantom `dbl > dbl` frames). Root cause: downstream O2 passes smear the `invoke` and `return` bracket markers across *every* instruction of an inlined body, and the spec didn't explicitly forbid that or separate the two reconstruction concerns. This amendment makes the contract unambiguous so both the compiler (emission) and the UI (reconstruction) have a firm reference.

## What changes
- **Bracketed emission is required.** `invoke` goes on the first instruction of a body, `return` on the last. Compilers must **not** duplicate either across interior instructions — repeating them pushes/pops spurious activations.
- **Single-instruction body exception.** A body whose entry and exit coincide legitimately carries both `invoke` and `return` on that one instruction; a debugger processes them push-then-pop (same pattern a tailcall back-edge already uses).
- **Display semantics stated.** `invoke` opens an activation inclusive of its instruction; `return` closes it *after* its instruction (the return instruction is still inside the activation).
- **Lifetime vs membership separated.** Push/pop determines *when* a virtual activation is open (its lifetime); per-instruction `transform:["inline"]` membership determines *which* open activation an instruction belongs to. An activation stays open across non-member (interleaved caller) instructions, which are attributed to the enclosing activation.

Companion PRs into `transform-context`: compiler de-smears the emission to boundary instructions; ui implements push/pop + membership-attribution reconstruction with an inline chip (task #23).