### PR TITLE
format: add Name context type and guard to TS types

### DIFF
--- a/packages/format/src/types/program/context.test.ts
+++ b/packages/format/src/types/program/context.test.ts
@@ -7,6 +7,10 @@ testSchemaGuards("ethdebug/format/program/context", [
     guard: isContext,
   },
   {
+    schema: "schema:ethdebug/format/program/context/name",
+    guard: Context.isName,
+  },
+  {
     schema: "schema:ethdebug/format/program/context/code",
     guard: Context.isCode,
   },

--- a/packages/format/src/types/program/context.ts
+++ b/packages/format/src/types/program/context.ts
@@ -3,6 +3,7 @@ import { Type } from "#types/type";
 import { Pointer, isPointer } from "#types/pointer";
 
 export type Context =
+  | Context.Name
   | Context.Code
   | Context.Variables
   | Context.Remark
@@ -16,6 +17,7 @@ export type Context =
 
 export const isContext = (value: unknown): value is Context =>
   [
+    Context.isName,
     Context.isCode,
     Context.isVariables,
     Context.isRemark,
@@ -29,6 +31,16 @@ export const isContext = (value: unknown): value is Context =>
   ].some((guard) => guard(value));
 
 export namespace Context {
+  export interface Name {
+    name: string;
+  }
+
+  export const isName = (value: unknown): value is Name =>
+    typeof value === "object" &&
+    !!value &&
+    "name" in value &&
+    typeof value.name === "string";
+
   export interface Code {
     code: Materials.SourceRange;
   }


### PR DESCRIPTION
Closes #28.

The `name` context has a schema (`program/context/name`) but was never
mirrored into the TypeScript types — there was no `Context.Name`
interface, no `isName` guard, and `name` was absent from both the
`Context` union and the `isContext` guard list. Pre-existing gap,
independent of #236 (which is docs/schema-desc only).

This adds `Context.Name` (`{ name: string }`) and `isName`, mirroring
`isFrame`, and wires them into the `Context` union and `isContext` in
schema-canonical order (name first). Adds schema-guard test coverage for
the name context.

Unblocks upcoming consumers — `name` as an invoke/return correlation id
(#26) — before compiler/UI start reading names. Behavior-preserving
addition; no structural schema change.

Scope note: pairing/correlation logic (matching an invoke's declared
name to its return) is deliberately **not** here — that's trace-
reconstruction logic for the debugger/UI layer (#23/#25), not the format
data model.