### PR TITLE
format: add `activation` correlation id to invoke/return/revert types

### DIFF
--- a/packages/format/src/types/program/context.ts
+++ b/packages/format/src/types/program/context.ts
@@ -169,8 +169,9 @@ export namespace Context {
     Invoke.isInvocation(value.invoke);
 
   export namespace Invoke {
-    export type Invocation = Function.Identity &
-      (
+    export type Invocation = Function.Identity & {
+      activation?: string;
+    } & (
         | Invocation.InternalCall
         | Invocation.ExternalCall
         | Invocation.ContractCreation
@@ -180,7 +181,8 @@ export namespace Context {
       Function.isIdentity(value) &&
       (Invocation.isInternalCall(value) ||
         Invocation.isExternalCall(value) ||
-        Invocation.isContractCreation(value));
+        Invocation.isContractCreation(value)) &&
+      (!("activation" in value) || typeof value.activation === "string");
 
     export namespace Invocation {
       export interface InternalCall extends Function.Identity {
@@ -254,6 +256,7 @@ export namespace Context {
     export interface Info extends Function.Identity {
       data?: Function.PointerRef;
       success?: Function.PointerRef;
+      activation?: string;
     }
 
     export const isInfo = (value: unknown): value is Info =>
@@ -261,7 +264,8 @@ export namespace Context {
       typeof value === "object" &&
       !!value &&
       (!("data" in value) || Function.isPointerRef(value.data)) &&
-      (!("success" in value) || Function.isPointerRef(value.success));
+      (!("success" in value) || Function.isPointerRef(value.success)) &&
+      (!("activation" in value) || typeof value.activation === "string");
   }
 
   export interface Revert {
@@ -278,6 +282,7 @@ export namespace Context {
     export interface Info extends Function.Identity {
       reason?: Function.PointerRef;
       panic?: number;
+      activation?: string;
     }
 
     export const isInfo = (value: unknown): value is Info =>
@@ -285,7 +290,8 @@ export namespace Context {
       typeof value === "object" &&
       !!value &&
       (!("reason" in value) || Function.isPointerRef(value.reason)) &&
-      (!("panic" in value) || typeof value.panic === "number");
+      (!("panic" in value) || typeof value.panic === "number") &&
+      (!("activation" in value) || typeof value.activation === "string");
   }
 
   export interface Transform {


### PR DESCRIPTION
Follow-up to #240 (activation-id spec correction). Closes #34.

#240 adds an optional `activation` string on the `invoke`, `return`, and
`revert` context objects — the opening `invoke` and the closing
`return`/`revert` carry the same value, letting a debugger pair an
activation independent of trace order (disambiguating adjacent inlined
activations and surviving optimizer reordering).

This mirrors that in the TS types: adds `activation?: string` to
`Invoke.Invocation`, `Return.Info`, and `Revert.Info`. Placed per-object
to track the schema exactly — the schema adds `activation` on each of
invoke/return/revert, **not** on the shared `context/function` identity
schema (so `Function.Identity`/`isIdentity` stay untouched).

No guard change: `activation` is an optional field on an existing object,
not a new context discriminator — the unchanged guards already accept it
(they ignore extra properties). Verified by scratch-merging #240's schema
locally and running the format suite: all guard-vs-example tests pass
with the new `activation` examples present.

**Merge ordering:** land after #240 merges so the types track the merged
schema. No file overlap with #240 (this touches only
`packages/format/.../context.ts`; #240 touches schemas + mdx), so no
conflict either way — this is purely a don't-land-types-ahead-of-schema
courtesy.

Note (reviewer's call): every *other* optional field on these objects is
validated in its guard (e.g. `identifier`/`data`/`success` do an optional
`typeof`/pointer check), so strictly for consistency `activation` could
get a one-line `(!("activation" in v) || typeof v.activation === "string")`
in `isInvocation`/`Return.isInfo`/`Revert.isInfo`. Left out per architect's
"no guard changes" call; happy to add if you'd prefer the consistency.