### PR TITLE
format: add the Name context type and guard to the TS types

### DIFF
--- a/packages/format/src/types/program/context.test.ts
+++ b/packages/format/src/types/program/context.test.ts
@@ -7,6 +7,10 @@ testSchemaGuards("ethdebug/format/program/context", [
     guard: isContext,
   },
   {
+    schema: "schema:ethdebug/format/program/context/name",
+    guard: Context.isName,
+  },
+  {
     schema: "schema:ethdebug/format/program/context/code",
     guard: Context.isCode,
   },

--- a/packages/format/src/types/program/context.ts
+++ b/packages/format/src/types/program/context.ts
@@ -3,6 +3,7 @@ import { Type } from "#types/type";
 import { Pointer, isPointer } from "#types/pointer";
 
 export type Context =
+  | Context.Name
   | Context.Code
   | Context.Variables
   | Context.Remark
@@ -15,6 +16,7 @@ export type Context =
 
 export const isContext = (value: unknown): value is Context =>
   [
+    Context.isName,
     Context.isCode,
     Context.isVariables,
     Context.isRemark,
@@ -27,6 +29,16 @@ export const isContext = (value: unknown): value is Context =>
   ].some((guard) => guard(value));
 
 export namespace Context {
+  export interface Name {
+    name: string;
+  }
+
+  export const isName = (value: unknown): value is Name =>
+    typeof value === "object" &&
+    !!value &&
+    "name" in value &&
+    typeof value.name === "string";
+
   export interface Code {
     code: Materials.SourceRange;
   }


### PR DESCRIPTION
The `name` context has had a schema and spec page, but the TypeScript types never mirrored it — there was no `Context.Name` interface or `isName` guard, and `name` was absent from the `Context` union and `isContext`. Add them (matching the other context guards), so a bare `{ name }` context is recognized, plus schema-guard test coverage.