### PR TITLE
web/playground: source BUG examples from @ethdebug/bugc/examples

### DIFF
--- a/packages/bugc-react/src/examples.test.ts
+++ b/packages/bugc-react/src/examples.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The curated example set is sourced from `@ethdebug/bugc/examples`
+ * (the canonical `.bug` files), sliced down and stripped for display.
+ * These guards ensure the selection stays valid and editor-clean: the
+ * strings ship verbatim into the docs playground editor.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "@ethdebug/bugc";
+import { exampleSources } from "@ethdebug/bugc/examples";
+import { bugExamples } from "./examples.js";
+
+describe("bugExamples", () => {
+  it("is the curated trio (counter, functions, arrays)", () => {
+    expect(bugExamples.map((e) => e.name)).toEqual([
+      "counter",
+      "functions",
+      "arrays",
+    ]);
+  });
+
+  it("gives every example a display name and non-empty source", () => {
+    for (const ex of bugExamples) {
+      expect(ex.displayName.trim().length).toBeGreaterThan(0);
+      expect(ex.code.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("draws its sources from the canonical bugc examples", () => {
+    // Sanity: the raw sources the curation selects really exist
+    // upstream, so the selection can't silently drift to empty.
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        exampleSources,
+        "intermediate/owner-counter.bug",
+      ),
+    ).toBe(true);
+    expect(bugExamples.length).toBeGreaterThan(0);
+  });
+
+  it("strips bugc's inline test annotations for display", () => {
+    for (const ex of bugExamples) {
+      expect(ex.code).not.toContain("@test");
+      expect(ex.code).not.toContain("@expect");
+    }
+  });
+
+  // Each curated source must compile cleanly to bytecode — this is
+  // the guard that matters, since these ship straight to the editor.
+  for (const ex of bugExamples) {
+    it(`compiles ${ex.name} to bytecode without errors`, async () => {
+      const result = await compile({
+        to: "bytecode",
+        source: ex.code,
+        optimizer: { level: 0 },
+      });
+      expect(result.success).toBe(true);
+    });
+  }
+});

--- a/packages/bugc-react/src/examples.ts
+++ b/packages/bugc-react/src/examples.ts
@@ -1,0 +1,52 @@
+/**
+ * Curated BUG examples for the docs playground's example selector.
+ *
+ * The sources are the canonical `.bug` files shipped by
+ * `@ethdebug/bugc/examples` — the same files bugc's behavioral tests
+ * compile — so the playground never drifts from a hand-maintained copy.
+ * We select a small subset, label it for display, and strip bugc's
+ * inline test annotations so the editor shows clean source.
+ */
+
+import { exampleSources, stripTestAnnotations } from "@ethdebug/bugc/examples";
+
+/** A named, display-labelled BUG source for the example selector. */
+export interface BugExample {
+  /** Stable identifier (used as the <option> value). */
+  name: string;
+  /** Human-readable label shown in the dropdown. */
+  displayName: string;
+  /** Display-ready BUG source (test annotations stripped). */
+  code: string;
+}
+
+/**
+ * The curated subset, in display order. `path` refers into
+ * `@ethdebug/bugc/examples`; the sources stay upstream, only the
+ * selection and labels live here.
+ */
+const curated: { path: string; name: string; displayName: string }[] = [
+  {
+    path: "intermediate/owner-counter.bug",
+    name: "counter",
+    displayName: "Owned counter",
+  },
+  { path: "basic/functions.bug", name: "functions", displayName: "Functions" },
+  {
+    path: "intermediate/arrays.bug",
+    name: "arrays",
+    displayName: "Arrays & loops",
+  },
+];
+
+export const bugExamples: BugExample[] = curated.map(
+  ({ path, name, displayName }) => {
+    const source = exampleSources[path];
+    if (source === undefined) {
+      throw new Error(
+        `Curated example "${path}" is not in @ethdebug/bugc/examples`,
+      );
+    }
+    return { name, displayName, code: stripTestAnnotations(source) };
+  },
+);

--- a/packages/bugc-react/src/index.ts
+++ b/packages/bugc-react/src/index.ts
@@ -44,6 +44,9 @@ export {
   type EditorSourceRange,
 } from "#components/Editor";
 
+// Curated example programs (for playground selectors)
+export { bugExamples, type BugExample } from "./examples.js";
+
 // Utilities
 export {
   // Debug utilities

--- a/packages/bugc-react/vitest.config.ts
+++ b/packages/bugc-react/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: ["node_modules/", "dist/", "**/*.test.ts", "**/*.test.tsx"],
+    },
+  },
+});

--- a/packages/playground/src/playground/examples.ts
+++ b/packages/playground/src/playground/examples.ts
@@ -1,3 +1,5 @@
+import { exampleSources, stripTestAnnotations } from "@ethdebug/bugc/examples";
+
 export interface Example {
   name: string;
   displayName: string;
@@ -5,114 +7,124 @@ export interface Example {
   code: string;
 }
 
-// Import all .bug files from the bugc examples directory
-// Vite will inline the file contents at build time
-const exampleFiles = import.meta.glob("../../../bugc/examples/**/*.bug", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
-
-// Map the actual example files to the Example interface
-// Organized by category, showing only working examples
-export const examples: Example[] = [
+// Curated subset of the canonical `.bug` files shipped by
+// `@ethdebug/bugc/examples`, organized by category. The sources stay
+// upstream (bugc's behavioral tests compile the same files); only the
+// selection, labels, and display order live here. Test annotations are
+// stripped so the editor shows clean source.
+const curated: Array<{
+  path: string;
+  name: string;
+  displayName: string;
+  category: Example["category"];
+}> = [
   // Basic examples
   {
+    path: "basic/minimal.bug",
     name: "minimal",
     displayName: "Minimal",
     category: "basic",
-    code: exampleFiles["../../../bugc/examples/basic/minimal.bug"] || "",
   },
   {
+    path: "basic/conditionals.bug",
     name: "conditionals",
     displayName: "Conditionals",
     category: "basic",
-    code: exampleFiles["../../../bugc/examples/basic/conditionals.bug"],
   },
   {
+    path: "basic/functions.bug",
     name: "functions",
     displayName: "Functions",
     category: "basic",
-    code: exampleFiles["../../../bugc/examples/basic/functions.bug"],
   },
   {
+    path: "basic/array-length.bug",
     name: "array-length",
     displayName: "Array Length",
     category: "basic",
-    code: exampleFiles["../../../bugc/examples/basic/array-length.bug"],
   },
 
   // Intermediate examples
   {
+    path: "intermediate/owner-counter.bug",
     name: "owner-counter",
     displayName: "Owner Counter",
     category: "intermediate",
-    code: exampleFiles["../../../bugc/examples/intermediate/owner-counter.bug"],
   },
   {
+    path: "intermediate/arrays.bug",
     name: "arrays",
     displayName: "Arrays and Loops",
     category: "intermediate",
-    code: exampleFiles["../../../bugc/examples/intermediate/arrays.bug"],
   },
   {
+    path: "intermediate/mappings.bug",
     name: "mappings",
     displayName: "Mappings",
     category: "intermediate",
-    code: exampleFiles["../../../bugc/examples/intermediate/mappings.bug"],
   },
   {
+    path: "intermediate/scopes.bug",
     name: "scopes",
     displayName: "Variable Scopes",
     category: "intermediate",
-    code: exampleFiles["../../../bugc/examples/intermediate/scopes.bug"],
   },
   {
+    path: "intermediate/slices.bug",
     name: "slices",
     displayName: "Byte Slices",
     category: "intermediate",
-    code: exampleFiles["../../../bugc/examples/intermediate/slices.bug"],
   },
   {
+    path: "intermediate/calldata.bug",
     name: "calldata",
     displayName: "Calldata Access",
     category: "intermediate",
-    code: exampleFiles["../../../bugc/examples/intermediate/calldata.bug"],
   },
 
   // Advanced examples
   {
+    path: "advanced/nested-mappings.bug",
     name: "nested-mappings",
     displayName: "Nested Mappings",
     category: "advanced",
-    code: exampleFiles["../../../bugc/examples/advanced/nested-mappings.bug"],
   },
   {
+    path: "advanced/nested-arrays.bug",
     name: "nested-arrays",
     displayName: "Nested Arrays",
     category: "advanced",
-    code: exampleFiles["../../../bugc/examples/advanced/nested-arrays.bug"],
   },
   {
+    path: "advanced/nested-structs.bug",
     name: "nested-structs",
     displayName: "Nested Structs",
     category: "advanced",
-    code: exampleFiles["../../../bugc/examples/advanced/nested-structs.bug"],
   },
 
   // Optimization demos
   {
+    path: "optimizations/cse.bug",
     name: "cse",
     displayName: "CSE Demo",
     category: "optimizations",
-    code: exampleFiles["../../../bugc/examples/optimizations/cse.bug"],
   },
   {
+    path: "optimizations/constant-folding.bug",
     name: "constant-folding",
     displayName: "Constant Folding",
     category: "optimizations",
-    code: exampleFiles[
-      "../../../bugc/examples/optimizations/constant-folding.bug"
-    ],
   },
 ];
+
+export const examples: Example[] = curated.map(
+  ({ path, name, displayName, category }) => {
+    const source = exampleSources[path];
+    if (source === undefined) {
+      throw new Error(
+        `Curated example "${path}" is not in @ethdebug/bugc/examples`,
+      );
+    }
+    return { name, displayName, category, code: stripTestAnnotations(source) };
+  },
+);

--- a/packages/web/src/theme/BugcExample/BugPlayground.css
+++ b/packages/web/src/theme/BugcExample/BugPlayground.css
@@ -26,14 +26,16 @@
   align-items: center;
 }
 
-.bug-playground-opt-control {
+.bug-playground-opt-control,
+.bug-playground-example-control {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
 }
 
-.bug-playground-opt-control select {
+.bug-playground-opt-control select,
+.bug-playground-example-control select {
   padding: 0.25rem 0.5rem;
   border-radius: var(--ifm-global-radius);
   border: 1px solid var(--ifm-color-emphasis-300);

--- a/packages/web/src/theme/BugcExample/BugPlayground.tsx
+++ b/packages/web/src/theme/BugcExample/BugPlayground.tsx
@@ -18,6 +18,8 @@ import {
   IrView,
   CfgView,
   BytecodeView,
+  bugExamples,
+  type BugExample,
   type SourceRange,
   type BytecodeOutput,
 } from "@ethdebug/bugc-react";
@@ -129,8 +131,20 @@ async function compile(
 type TabType = "ast" | "ir" | "cfg" | "bytecode";
 
 export interface BugPlaygroundProps {
-  /** Initial code to display in the editor */
+  /**
+   * Initial code to display in the editor. When provided, the
+   * example selector is hidden by default (the embed is showing
+   * one specific program); when omitted, the playground opens on
+   * the first curated example and shows the selector.
+   */
   initialCode?: string;
+  /** Curated examples offered in the selector dropdown. */
+  examples?: BugExample[];
+  /**
+   * Force the example selector on or off. Defaults to showing it
+   * only when `initialCode` is not provided.
+   */
+  showExampleSelector?: boolean;
   /** Default optimization level (0-3) */
   defaultOptimizationLevel?: number;
   /** Whether to show optimization level selector */
@@ -143,33 +157,20 @@ export interface BugPlaygroundProps {
  * Interactive BUG compiler playground.
  */
 export function BugPlayground({
-  initialCode = `name Counter;
-
-storage {
-  [0] count: uint256;
-  [1] threshold: uint256;
-}
-
-create {
-  count = 0;
-  threshold = 100;
-}
-
-code {
-  // Increment the counter
-  count = count + 1;
-
-  // Check threshold
-  if (count >= threshold) {
-    count = 0;
-  }
-}
-`,
+  initialCode,
+  examples = bugExamples,
+  showExampleSelector,
   defaultOptimizationLevel = 3,
   showOptimizationSelector = true,
   height = "600px",
 }: BugPlaygroundProps): JSX.Element {
-  const [code, setCode] = useState(initialCode);
+  // Show the selector only when the embed hasn't pinned a specific
+  // program via initialCode (unless explicitly overridden).
+  const showSelector =
+    showExampleSelector ?? (initialCode === undefined && examples.length > 0);
+
+  const [selectedExample, setSelectedExample] = useState(examples[0]?.name);
+  const [code, setCode] = useState(initialCode ?? examples[0]?.code ?? "");
   const [optimizationLevel, setOptimizationLevel] = useState(
     defaultOptimizationLevel,
   );
@@ -185,10 +186,12 @@ code {
     setHighlightedRanges(ranges);
   }, []);
 
-  const handleCompile = useCallback(async () => {
+  // Compile an explicit source (so example switches recompile the
+  // just-selected program, not the stale `code` from closure).
+  const runCompile = useCallback(async (src: string, level: number) => {
     setIsCompiling(true);
     try {
-      const result = await compile(code, optimizationLevel);
+      const result = await compile(src, level);
       setCompileResult(result);
       if (!result.success) {
         setActiveTab("ast"); // Show AST tab for errors
@@ -202,11 +205,27 @@ code {
     } finally {
       setIsCompiling(false);
     }
-  }, [code, optimizationLevel]);
+  }, []);
+
+  const handleCompile = useCallback(() => {
+    runCompile(code, optimizationLevel);
+  }, [runCompile, code, optimizationLevel]);
+
+  const handleExampleChange = useCallback(
+    (name: string) => {
+      const example = examples.find((e) => e.name === name);
+      if (!example) return;
+      setSelectedExample(name);
+      setCode(example.code);
+      runCompile(example.code, optimizationLevel);
+    },
+    [examples, optimizationLevel, runCompile],
+  );
 
   // Compile on mount
   useEffect(() => {
-    handleCompile();
+    runCompile(code, optimizationLevel);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const tabs: { id: TabType; label: string }[] = [
@@ -220,6 +239,21 @@ code {
     <div className="bug-playground" style={{ height }}>
       <div className="bug-playground-header">
         <div className="bug-playground-controls">
+          {showSelector && (
+            <label className="bug-playground-example-control">
+              <span>Example:</span>
+              <select
+                value={selectedExample}
+                onChange={(e) => handleExampleChange(e.target.value)}
+              >
+                {examples.map((example) => (
+                  <option key={example.name} value={example.name}>
+                    {example.displayName}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           {showOptimizationSelector && (
             <label className="bug-playground-opt-control">
               <span>Optimization:</span>


### PR DESCRIPTION
Both playgrounds showed BUG programs maintained separately from the
canonical `.bug` files under `packages/bugc/examples` — the docs
BugPlayground had no example picker, and the standalone playground
loaded sources with a Vite `import.meta.glob(...?raw)` that only works
under Vite. Neither stayed in step with the sources bugc actually tests.

Both now consume the shared `@ethdebug/bugc/examples` map, which ships
the canonical sources as inlined string literals so webpack (docs) and
Vite (playground) can import them without a filesystem glob. Curation
stays consumer-side — each keeps a small list picking which examples to
show, their labels, and (playground) their category — and applies
`stripTestAnnotations` so the editor shows clean source without bugc's
inline `@test` / `@expect` directives.

- **docs BugPlayground:** adds an example selector (curated trio: an
  owned counter, functions, arrays & loops), shown when the embed hasn't
  pinned a program via `initialCode`.
- **standalone playground:** drops `import.meta.glob`; same curated,
  categorized set, now keyed by canonical example path.
- unit coverage that the curated sets resolve to real sources, strip
  clean, and compile to bytecode.

One deliberate behavior change worth a look in review: the standalone
playground previously rendered raw sources, so `@test` annotation blocks
were visible in its editor. It now strips them (same as the docs
selector), which is why the playground's `examples.ts` calls
`stripTestAnnotations`. Easy to drop that one call if you'd rather it
keep showing raw.

Supersedes the earlier hand-inlined selector (#247).