### PR TITLE
bugc-react: show instruction offsets in hex

### DIFF
--- a/packages/bugc-react/src/components/BytecodeView.tsx
+++ b/packages/bugc-react/src/components/BytecodeView.tsx
@@ -175,7 +175,9 @@ function InstructionsView({
             ) : (
               <span className="debug-info-spacer"></span>
             )}
-            <span className="pc">{currentPc.toString().padStart(4, "0")}</span>
+            <span className="pc">
+              {`0x${currentPc.toString(16).padStart(4, "0")}`}
+            </span>
             <span className="opcode">{instruction.mnemonic}</span>
             {instruction.immediates && instruction.immediates.length > 0 && (
               <span className="immediates">


### PR DESCRIPTION
The bytecode disassembly in the BUG playground lists each instruction with its program-counter offset. Those offsets were rendered in decimal, but EVM offsets/PCs are conventionally hexadecimal.

Render each offset as a lowercase, `0x`-prefixed hex value, matching the convention already used for the raw bytecode hex and PUSH immediates in the same view. Display-only change; no data or semantics are affected.