### PR TITLE
bugc: emit a plain code context on synthesized prelude ops

### DIFF
--- a/packages/bugc/src/evmgen/generation/block.ts
+++ b/packages/bugc/src/evmgen/generation/block.ts
@@ -275,15 +275,10 @@ function initializeMemory<S extends Stack>(
   const debug = sourceInfo
     ? {
         context: {
-          gather: [
-            { remark: "initialize free memory pointer" },
-            {
-              code: {
-                source: { id: sourceInfo.sourceId },
-                range: sourceInfo.loc,
-              },
-            },
-          ],
+          code: {
+            source: { id: sourceInfo.sourceId },
+            range: sourceInfo.loc,
+          },
         } as Format.Program.Context,
       }
     : {

--- a/packages/bugc/src/evmgen/generation/function.ts
+++ b/packages/bugc/src/evmgen/generation/function.ts
@@ -268,15 +268,10 @@ function makePrologueDebug(func: Ir.Function): Debug {
   return func.sourceId && func.loc
     ? {
         context: {
-          gather: [
-            { remark: "prologue: allocate call frame" },
-            {
-              code: {
-                source: { id: func.sourceId },
-                range: func.loc,
-              },
-            },
-          ],
+          code: {
+            source: { id: func.sourceId },
+            range: func.loc,
+          },
         } as Format.Program.Context,
       }
     : {

--- a/packages/bugc/src/evmgen/generation/module.ts
+++ b/packages/bugc/src/evmgen/generation/module.ts
@@ -111,17 +111,10 @@ export function generate(
     module.main.sourceId && module.main.loc
       ? {
           context: {
-            gather: [
-              {
-                remark: "guard: prevent fall-through into functions",
-              },
-              {
-                code: {
-                  source: { id: module.main.sourceId },
-                  range: module.main.loc,
-                },
-              },
-            ],
+            code: {
+              source: { id: module.main.sourceId },
+              range: module.main.loc,
+            },
           },
         }
       : {


### PR DESCRIPTION
Three synthesized prelude/boilerplate instructions — the
free-memory-pointer initialization, the function-call-frame
prologue, and the STOP fall-through guard between `main` and the
user functions — each attached a debug `gather` wrapping a remark
and a code source range.

`gather` exists to combine contexts whose keys would otherwise
collide in a single object (for example two `code` ranges, or two
`variables` views of the same value). A remark and a code range
have distinct keys, so the gather is pure overhead — the two can
sit as siblings, which is already how the main instruction path
composes `code` and `variables`.

This flattens all three sites to a plain code context and drops the
remark: it was redundant with the code range and never surfaced in
the trace view (it was nested inside the gather, which the opcode
list doesn't unwrap). The code source range is unchanged, so these
ops still map to their enclosing function.