### PR TITLE
web: drop a broken tail-call walkthrough link from the trace playground

### DIFF
--- a/packages/web/docs/explore/trace-playground.mdx
+++ b/packages/web/docs/explore/trace-playground.mdx
@@ -92,7 +92,6 @@ Flip the **Opt** selector between **O0** and **O2** to see the difference:
 at **O0** each program calls its helper the ordinary way; at **O2** the
 transforms above take over. For how these transforms compose with
 invoke/return, see the
-[transform context spec](/spec/program/context/transform) and the
-[tail-call optimization walkthrough](/docs/core-schemas/programs/tracing).
+[transform context spec](/spec/program/context/transform).
 
 </TracePlayground>


### PR DESCRIPTION
The "Watching the optimizer" section closed by pointing readers to a "tail-call optimization walkthrough" — but the link targeted the bare tracing reference page (no walkthrough there, no anchor), and singling out tail-call right after the inlining example read wrong. Drop that link and end the sentence on the transform-context spec reference.