### PR TITLE
web: use the SimpleFunctions example in the trace playground

### DIFF
--- a/packages/web/docs/core-schemas/programs/tracing-examples.ts
+++ b/packages/web/docs/core-schemas/programs/tracing-examples.ts
@@ -1,3 +1,15 @@
+import { exampleSources, stripTestAnnotations } from "@ethdebug/bugc/examples";
+
+/**
+ * SimpleFunctions, referenced from the canonical bugc examples — the same
+ * `basic/functions.bug` the BUG playground dropdown sources — with bugc's
+ * inline test annotations stripped for display. Kept DRY rather than
+ * copying the `.bug` source here.
+ */
+export const simpleFunctions = stripTestAnnotations(
+  exampleSources["basic/functions.bug"],
+);
+
 export const counterIncrement = `name Counter;
 
 storage {
@@ -50,26 +62,6 @@ code {
   sum = a + b;
   a = a + 1;
   b = b + 1;
-}`;
-
-export const functionCallAndReturn = `name Adder;
-
-define {
-  function add(a: uint256, b: uint256) -> uint256 {
-    return a + b;
-  };
-}
-
-storage {
-  [0] result: uint256;
-}
-
-create {
-  result = 0;
-}
-
-code {
-  result = add(3, 4);
 }`;
 
 export const mutualRecursion = `name EvenOdd;

--- a/packages/web/docs/explore/trace-playground.mdx
+++ b/packages/web/docs/explore/trace-playground.mdx
@@ -7,7 +7,7 @@ sidebar_label: "Step through an execution trace"
 import { TracePlayground, TraceExample } from "@theme/ProgramExample";
 import {
   counterIncrement,
-  functionCallAndReturn,
+  simpleFunctions,
   tailRecursiveFactorial,
   inlineDemo,
 } from "../core-schemas/programs/tracing-examples";
@@ -39,14 +39,16 @@ the context attached to each instruction.
 
 ## A function call
 
-Real programs call functions, and the debugger follows them. Watch the
-call stack push a frame on the JUMP into `add` (an **invoke** context)
-and pop it on the JUMP back (a **return** context).
+Real programs call functions, and the debugger follows them.
+`SimpleFunctions` calls an `add` helper directly, then calls `addThree` —
+which itself calls `add` twice — so the call stack nests two frames deep.
+Each JUMP into a function pushes a frame (an **invoke** context); each
+JUMP back pops it (a **return** context).
 
 <TraceExample
-  title="Function call and return"
-  description="Calls an internal add function and stores the result"
-  source={functionCallAndReturn}
+  title="Nested function calls"
+  description="Calls add directly, then addThree — which calls add twice — storing 60"
+  source={simpleFunctions}
 />
 
 For the exact shape of invoke, return, and revert contexts, see the


### PR DESCRIPTION
The explore trace playground's "A function call" demo compiled a minimal two-line `Adder`. Swap it for `SimpleFunctions` — the same `basic/functions.bug` the BUG playground dropdown uses — which calls `add` directly and then a nested `addThree` that calls `add` twice, so the call stack nests two frames deep. The source is referenced from the canonical `@ethdebug/bugc/examples` export (test annotations stripped) rather than copied into `tracing-examples.ts`, and the section prose is updated to match.