### PR TITLE
format: align pointer identifier and contract type guards with their schemas

### DIFF
--- a/packages/format/src/types/pointer/pointer.test.ts
+++ b/packages/format/src/types/pointer/pointer.test.ts
@@ -1,9 +1,57 @@
+import { describe, it, expect } from "vitest";
+
 import { testSchemaGuards } from "#test/guards";
+import { describeSchema } from "#describe";
 
 import { Pointer, isPointer } from "./pointer.js";
 
+const identifierSchema = "schema:ethdebug/format/pointer/identifier";
+
+describe("Pointer.isIdentifier", () => {
+  const valid = ["a", "a0", "-$", "__init__", "_x", "A", "foo-bar", "x$y"];
+
+  const invalid = [
+    "", // empty
+    "0abc", // leading digit
+    "$x", // leading $
+    "a b", // space
+    "foo\\bar", // embedded backslash — accepted before the fix
+    "\\", // lone backslash
+    "foo\tbar", // tab
+    "café", // non-ASCII letter
+  ];
+
+  it.each(valid)("accepts %j", (value) => {
+    expect(Pointer.isIdentifier(value)).toBe(true);
+  });
+
+  it.each(invalid)("rejects %j", (value) => {
+    expect(Pointer.isIdentifier(value)).toBe(false);
+  });
+
+  it("agrees with the identifier schema pattern over a corpus", () => {
+    const { schema } = describeSchema({ schema: identifierSchema });
+    const { pattern } = schema as { pattern: string };
+    const schemaRegex = new RegExp(pattern);
+
+    for (const value of [...valid, ...invalid]) {
+      expect(Pointer.isIdentifier(value)).toBe(schemaRegex.test(value));
+    }
+  });
+
+  it("rejects non-string inputs", () => {
+    for (const value of [undefined, null, 42, {}, ["a"]]) {
+      expect(Pointer.isIdentifier(value)).toBe(false);
+    }
+  });
+});
+
 const expressionSchema = "schema:ethdebug/format/pointer/expression";
 testSchemaGuards("ethdebug/format/pointer", [
+  {
+    schema: identifierSchema,
+    guard: Pointer.isIdentifier,
+  },
   {
     schema: expressionSchema,
     guard: Pointer.isExpression,

--- a/packages/format/src/types/pointer/pointer.ts
+++ b/packages/format/src/types/pointer/pointer.ts
@@ -6,7 +6,7 @@ export const isPointer = (value: unknown): value is Pointer =>
 export namespace Pointer {
   export type Identifier = string;
   export const isIdentifier = (value: unknown): value is Identifier =>
-    typeof value === "string" && /^[a-zA-Z_\\-]+[a-zA-Z0-9$_\\-]*$/.test(value);
+    typeof value === "string" && /^[a-zA-Z_-]+[a-zA-Z0-9$_-]*$/.test(value);
 
   export type Region =
     | Region.Stack

--- a/packages/format/src/types/type/index.test.ts
+++ b/packages/format/src/types/type/index.test.ts
@@ -1,4 +1,9 @@
+import { describe, it, expect } from "vitest";
+
 import { testSchemaGuards } from "#test/guards";
+// loads schemas into the global hyperjump validator + `toValidate` matcher
+import "#test/hyperjump";
+
 import { Type, isType } from "./index.js";
 
 testSchemaGuards("ethdebug/format/type", [
@@ -96,3 +101,54 @@ testSchemaGuards("ethdebug/format/type", [
     guard: Type.isWrapper,
   },
 ] as const);
+
+// The contract type's schema uses a oneOf to distinguish normal /
+// library / interface contracts via the `library` and `interface`
+// flags. The guard must carry those flags and agree with the schema —
+// in particular it must reject a contract that sets both flags true
+// (which matches two oneOf branches at once).
+describe("Type.Elementary.isContract flag semantics", () => {
+  const contractSchema = "schema:ethdebug/format/type/elementary/contract";
+
+  const legal = [
+    { title: "normal (flags omitted)", value: { kind: "contract" } },
+    {
+      title: "normal (flags explicitly false)",
+      value: { kind: "contract", library: false, interface: false },
+    },
+    { title: "library", value: { kind: "contract", library: true } },
+    { title: "interface", value: { kind: "contract", interface: true } },
+  ] as const;
+
+  const illegal = [
+    {
+      title: "both library and interface true",
+      value: { kind: "contract", library: true, interface: true },
+    },
+  ] as const;
+
+  for (const { title, value } of legal) {
+    it(`accepts the ${title} contract shape`, async () => {
+      expect(Type.Elementary.isContract(value)).toBe(true);
+      // guard agrees with the schema
+      await expect(value).toValidate({ schema: contractSchema });
+    });
+  }
+
+  for (const { title, value } of illegal) {
+    it(`rejects a contract with ${title}`, async () => {
+      expect(Type.Elementary.isContract(value)).toBe(false);
+      // guard agrees with the schema
+      await expect(value).not.toValidate({ schema: contractSchema });
+    });
+  }
+
+  it("rejects non-boolean flag values", () => {
+    expect(
+      Type.Elementary.isContract({ kind: "contract", library: "true" }),
+    ).toBe(false);
+    expect(Type.Elementary.isContract({ kind: "contract", interface: 1 })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/format/src/types/type/index.ts
+++ b/packages/format/src/types/type/index.ts
@@ -237,6 +237,8 @@ export namespace Type {
       class?: "elementary";
       kind: "contract";
       payable?: boolean;
+      library?: boolean;
+      interface?: boolean;
       definition?: Definition;
     }
 
@@ -246,6 +248,18 @@ export namespace Type {
       mayHaveClass(value, "elementary") &&
       hasKind(value, "contract") &&
       (!("payable" in value) || typeof value.payable === "boolean") &&
+      (!("library" in value) || typeof value.library === "boolean") &&
+      (!("interface" in value) || typeof value.interface === "boolean") &&
+      // The schema's oneOf splits contract types three ways (normal /
+      // library / interface). `library` and `interface` cannot both be
+      // true: that shape satisfies two branches at once, which the
+      // oneOf rejects.
+      !(
+        "library" in value &&
+        value.library === true &&
+        "interface" in value &&
+        value.interface === true
+      ) &&
       (!("definition" in value) || isDefinition(value.definition));
 
     export interface Enum {


### PR DESCRIPTION
Two format-package type guards had drifted from the schemas they mirror.

## `Pointer.isIdentifier`

The guard copied the identifier schema's regex with its YAML escaping intact. In `schemas/pointer/identifier.schema.yaml` the character classes are written `[a-zA-Z_\\-]` / `[a-zA-Z0-9$_\\-]`, where the doubled backslash is YAML escaping for a single backslash that, in the regex, escapes the hyphen. Copied verbatim into a JavaScript regex literal, `\\-` no longer means "escaped hyphen" — it matches a literal backslash. The guard therefore accepted identifiers containing backslashes (e.g. `"foo\bar"`) that the schema rejects.

The fix drops the extra backslash so the classes match the schema exactly (a plain trailing hyphen, literal in that position).

## `Type.Elementary.isContract`

The contract type schema uses a `oneOf` to distinguish normal, library, and interface contract types through the `library` and `interface` boolean flags, but the `Contract` interface and guard dropped both flags. The guard accepted a contract that sets both flags true — a shape the schema rejects, since it satisfies two `oneOf` branches at once — and the interface lost the three-way distinction.

The fix adds the flags to the interface and the guard, validating each as a boolean when present and rejecting the both-true shape, matching the current schema semantics. (Tightening the schema's own flag typing is tracked separately.)

## Tests

Both guards gain coverage that asserts guard/schema agreement, so they cannot silently drift again:

- identifier: the schema examples via the shared `testSchemaGuards` harness, plus a corpus checked against the pattern read directly from the schema (backslash strings rejected, valid identifiers accepted).
- contract: the three legal shapes and the both-true rejection, each checked against the guard and validated against the schema.