### PR TITLE
format: correct schema examples and drop dead keywords

### DIFF
--- a/schemas/info.schema.yaml
+++ b/schemas/info.schema.yaml
@@ -14,7 +14,6 @@ properties:
     type: array
     items:
       $ref: "schema:ethdebug/format/program"
-    additionalItems: false
 
   compilation:
     $ref: "schema:ethdebug/format/materials/compilation"

--- a/schemas/info/resources.schema.yaml
+++ b/schemas/info/resources.schema.yaml
@@ -63,7 +63,7 @@ examples:
               location: storage
               slot: contract_variable_slot__struct__Coordinate__storage
               offset: 0
-              length: 128
+              length: 16
             - name: member__y__struct__Coordinate__storage
               location: storage
               slot: contract_variable_slot__struct__Coordinate__storage
@@ -71,4 +71,4 @@ examples:
                 $sum:
                   - .offset: member__x__struct__Coordinate__storage
                   - .length: member__x__struct__Coordinate__storage
-              length: 128
+              length: 16

--- a/schemas/pointer/collection/list.schema.yaml
+++ b/schemas/pointer/collection/list.schema.yaml
@@ -38,6 +38,5 @@ examples:
       each: "index"
       is:
         location: memory
-        offset:
-          $read: "index"
+        offset: "index"
         length: 1

--- a/schemas/pointer/collection/scope.schema.yaml
+++ b/schemas/pointer/collection/scope.schema.yaml
@@ -16,10 +16,10 @@ properties:
   define:
     title: Mapping of variables to expression value
     type: object
-    patternProperties:
-      "^[a-zA-Z_\\-]+[a-zA-Z0-9$_\\-]*$":
-        $ref: "schema:ethdebug/format/pointer/expression"
-    additionalProperties: false
+    propertyNames:
+      $ref: "schema:ethdebug/format/pointer/identifier"
+    additionalProperties:
+      $ref: "schema:ethdebug/format/pointer/expression"
   in:
     $ref: "schema:ethdebug/format/pointer"
 

--- a/schemas/pointer/template.schema.yaml
+++ b/schemas/pointer/template.schema.yaml
@@ -16,7 +16,6 @@ properties:
     type: array
     items:
       $ref: "schema:ethdebug/format/pointer/identifier"
-    additionalItems: false
 
   for:
     $ref: "schema:ethdebug/format/pointer"

--- a/schemas/program.schema.yaml
+++ b/schemas/program.schema.yaml
@@ -50,7 +50,6 @@ properties:
       The full array of instructions for the bytecode.
     items:
       $ref: "schema:ethdebug/format/program/instruction"
-    additionalItems: false
 
 required:
   - contract

--- a/schemas/program/context/function/invoke.schema.yaml
+++ b/schemas/program/context/function/invoke.schema.yaml
@@ -314,27 +314,9 @@ examples:
   # is no physical call instruction and no code target to
   # point at. The invoke context still records the callee's
   # identity so the debugger can maintain a source-level call
-  # stack.
-  - invoke:
-      identifier: "transfer"
-      declaration:
-        source:
-          id: 0
-        range:
-          offset: 128
-          length: 95
-      jump: true
-
-  # -----------------------------------------------------------
-  # Inlined internal call: no target pointer
-  # -----------------------------------------------------------
-  # When the compiler inlines a function, the JUMP that would
-  # normally carry the invoke context has been elided — there
-  # is no physical call instruction and no code target to
-  # point at. The invoke context still records the callee's
-  # identity so the debugger can maintain a source-level call
-  # stack, and a `transform: ["inline"]` context (typically
-  # via `gather`) annotates the inlining.
+  # stack, and a `transform: ["inline"]` context annotates the
+  # inlining — composed flat alongside the invoke on the same
+  # context object (the two carry disjoint keys).
   - invoke:
       identifier: "transfer"
       declaration:

--- a/schemas/program/context/gather.schema.yaml
+++ b/schemas/program/context/gather.schema.yaml
@@ -14,7 +14,6 @@ properties:
     items:
       $ref: "schema:ethdebug/format/program/context"
     minItems: 2
-    additionalItems: false
 required:
   - gather
 

--- a/schemas/program/context/pick.schema.yaml
+++ b/schemas/program/context/pick.schema.yaml
@@ -15,7 +15,6 @@ properties:
     items:
       $ref: "schema:ethdebug/format/program/context"
     minItems: 2
-    additionalItems: false
 required:
   - pick
 

--- a/schemas/program/context/variables.schema.yaml
+++ b/schemas/program/context/variables.schema.yaml
@@ -19,7 +19,6 @@ properties:
     items:
       $ref: "#/$defs/Variable"
     minItems: 1
-    additionalItems: false
 required:
   - variables
 

--- a/schemas/type/base.schema.yaml
+++ b/schemas/type/base.schema.yaml
@@ -66,11 +66,11 @@ $defs:
             bits: 256
       - kind: struct
         contains:
-          - member: x
+          - name: x
             type:
               kind: uint
               bits: 256
-          - member: y
+          - name: y
             type:
               kind: uint
               bits: 256

--- a/schemas/type/definition.schema.yaml
+++ b/schemas/type/definition.schema.yaml
@@ -5,8 +5,7 @@ title: ethdebug/format/type/definition
 description: |
   Object containing name and location information for a type.
 
-  This schema does not require any particular field, but it **must** contain
-  at least one property.
+  This schema **must** specify at least one of `name` or `location`.
 
 type: object
 properties:


### PR DESCRIPTION
This PR corrects a set of example and prose defects surfaced by a sweep over the schemas. All are documentation- or validation-hygiene fixes; none change the accepted shape of any valid instance.

- **type/base** — the struct example labeled its members with a `member:` key, but the canonical struct schema (and every other example) names that field `name:`. No schema defines `member`.
- **pointer/collection/list** — the example obtained the loop index with `{ $read: "index" }`. `$read` reads bytes from a named *region*; the list index declared by `each` is a scalar variable, referenced bare. Corrected to `offset: "index"`.
- **info/resources** — the packed-struct pointer template sized its two `uint128` members as `128` (bits) instead of `16` (bytes), which put member `y` at offset `128`, past the word boundary. Both members are now 16 bytes, packing `x` at offset 0 and `y` at offset 16 within one slot.
- **program/context/function/invoke** — the inlined-call comment said a `transform: ["inline"]` context accompanies the invoke "typically via `gather`". `gather` is for colliding keys; `invoke` and `transform` are disjoint and compose flat on one context object, and the comment now says so. The near-duplicate inlined-call example (identical heading and prose, no distinct illustration) is removed.
- **pointer/collection/scope** — `define` validated its keys with an inline copy of the identifier pattern; it now references the identifier schema via `propertyNames`, matching `collection/reference` and `collection/templates` so the pattern cannot silently drift.
- **type/definition** — the description claimed the schema "does not require any particular field", but the `anyOf` requires `name` or `location`. The prose now matches the constraint.
- **Dead `additionalItems: false`** removed where it is inert — the keyword was dropped in JSON Schema 2020-12 and, even under earlier drafts, has no effect when `items` is a single schema: `program`, `info`, `pointer/template`, and `program/context/gather` / `pick` / `variables`.

Schema example and validity tests pass.