### PR TITLE
format: fix the program example's pre-execution stack pointers

### DIFF
--- a/schemas/program.schema.yaml
+++ b/schemas/program.schema.yaml
@@ -71,7 +71,6 @@ examples:
     # code {
     #   let localValue = storedValue;
     #   storedValue += 1;
-    #   value = tmp;
     # };
     # ```
     contract:
@@ -90,16 +89,32 @@ examples:
           pointer:
             location: storage
             slot: 0
+    # Each instruction's pointers describe the machine state the
+    # debugger observes when stopped at that instruction, i.e.
+    # before it executes; stack `slot` counts from the top of
+    # that pre-execution stack.
     instructions:
       - offset: 0
+        # about to PUSH0; stack: (empty)
         operation:
           mnemonic: PUSH0
         context:
           variables:
             - *stored-value
       - offset: 1
+        # about to SLOAD the slot pushed by PUSH0; stack: [0x00].
+        # localValue is not observable until SLOAD produces it, so
+        # it first appears at offset 2.
         operation:
           mnemonic: SLOAD
+        context:
+          variables:
+            - *stored-value
+      - offset: 2
+        # about to PUSH1; stack: [localValue] (top is slot 0)
+        operation:
+          mnemonic: PUSH1
+          arguments: ["0x01"]
         context:
           variables:
             - *stored-value
@@ -111,37 +126,28 @@ examples:
               pointer:
                 location: stack
                 slot: 0
-      - offset: 2
-        operation:
-          mnemonic: PUSH1
-          arguments: ["0x01"]
-        context:
-          variables:
-            - *stored-value
-            - <<: *local-value
-              pointer:
-                location: stack
-                slot: 1
-
       - offset: 4
+        # about to ADD; stack: [localValue, 0x01], so localValue is
+        # one below the top (slot 1). ADD then consumes it.
         operation:
           mnemonic: ADD
         context:
           variables:
             - *stored-value
-            - *local-value
+            - <<: *local-value
+              pointer:
+                location: stack
+                slot: 1
       - offset: 5
+        # about to PUSH0; stack: [storedValue + 1]. localValue was
+        # consumed by ADD and is no longer in scope.
         operation:
           mnemonic: PUSH0
         context:
           variables:
             - *stored-value
-            - <<: *local-value
-              pointer:
-                location: stack
-                slot: 1
-
       - offset: 6
+        # about to SSTORE; stack: [storedValue + 1, 0x00]
         operation:
           mnemonic: SSTORE
         context:


### PR DESCRIPTION
The `Incrementer` example in `program.schema.yaml` sizes its stack-resident local against post-execution machine state, contradicting the pointer convention the instruction schema declares.

**Convention** (`program/instruction.schema.yaml`, and the `invoke` schema's `InternalCall` note): a context's pointers describe the machine state a debugger observes when it is stopped **at** the instruction — that is, before the instruction executes. Stack `slot` counts from the top of that pre-execution stack.

Applying that convention to `let localValue = storedValue; storedValue += 1;` (call bytecode), the pre-execution stack at each instruction is:

| offset | op | pre-exec stack (top → bottom) | localValue |
|-------:|------|-------------------------------|------------|
| 0 | `PUSH0` | *(empty)* | — |
| 1 | `SLOAD` | `[0x00]` | — (SLOAD produces it) |
| 2 | `PUSH1 0x01` | `[localValue]` | **slot 0** |
| 4 | `ADD` | `[localValue, 0x01]` | **slot 1** (ADD consumes it) |
| 5 | `PUSH0` | `[storedValue+1]` | out of scope |
| 6 | `SSTORE` | `[storedValue+1, 0x00]` | out of scope |

So `localValue` is observable only at offsets 2 and 4. It first appears at offset **2** — one step after the `SLOAD` that computes it, because its value is not on the stack at the `SLOAD` trace step itself — and is gone once `ADD` consumes it. The previous example placed it at slot 0 as early as offset 1 and kept it live through offset 5, which would make a debugger display it off by one. `storedValue` stays at storage slot 0 throughout.

Per-offset stack notes are inlined so the slot math is checkable against the ops, and a stale `value = tmp;` line (a leftover from an earlier naming of the pseudo-code) is removed.

Schema example and validity tests pass.