### PR TITLE
format: tighten type and context validation constraints

### DIFF
--- a/schemas/pointer/region.schema.yaml
+++ b/schemas/pointer/region.schema.yaml
@@ -9,24 +9,31 @@ properties:
   location:
     $ref: "#/$defs/Location"
 
+required:
+  - location
+
 allOf:
   - if:
+      required:
+        - location
       properties:
         location:
           const: stack
-
     then:
       $ref: "schema:ethdebug/format/pointer/region/stack"
 
   - if:
+      required:
+        - location
       properties:
         location:
           const: memory
-
     then:
       $ref: "schema:ethdebug/format/pointer/region/memory"
 
   - if:
+      required:
+        - location
       properties:
         location:
           const: storage
@@ -34,6 +41,8 @@ allOf:
       $ref: "schema:ethdebug/format/pointer/region/storage"
 
   - if:
+      required:
+        - location
       properties:
         location:
           const: calldata
@@ -41,6 +50,8 @@ allOf:
       $ref: "schema:ethdebug/format/pointer/region/calldata"
 
   - if:
+      required:
+        - location
       properties:
         location:
           const: returndata
@@ -48,6 +59,8 @@ allOf:
       $ref: "schema:ethdebug/format/pointer/region/returndata"
 
   - if:
+      required:
+        - location
       properties:
         location:
           const: transient
@@ -55,6 +68,8 @@ allOf:
       $ref: "schema:ethdebug/format/pointer/region/transient"
 
   - if:
+      required:
+        - location
       properties:
         location:
           const: code

--- a/schemas/program/context/name.schema.yaml
+++ b/schemas/program/context/name.schema.yaml
@@ -25,6 +25,7 @@ type: object
 properties:
   name:
     type: string
+    minLength: 1
 required:
   - name
 

--- a/schemas/type/complex/function.schema.yaml
+++ b/schemas/type/complex/function.schema.yaml
@@ -62,6 +62,10 @@ properties:
   definition:
     $ref: "schema:ethdebug/format/type/definition"
 
+required:
+  - kind
+  - contains
+
 oneOf:
   - type: object
     title: External function type
@@ -86,7 +90,9 @@ oneOf:
                 title: Contract type wrapper
                 properties:
                   type:
-                    $ref: "schema:ethdebug/format/type/elementary/contract"
+                    oneOf:
+                      - $ref: "schema:ethdebug/format/type/elementary/contract"
+                      - $ref: "schema:ethdebug/format/type/reference"
     required:
       - external
 
@@ -161,4 +167,6 @@ $defs:
         type: object
         properties:
           type:
-            $ref: "schema:ethdebug/format/type/complex/tuple"
+            oneOf:
+              - $ref: "schema:ethdebug/format/type/complex/tuple"
+              - $ref: "schema:ethdebug/format/type/reference"

--- a/schemas/type/elementary.schema.yaml
+++ b/schemas/type/elementary.schema.yaml
@@ -8,6 +8,10 @@ type: object
 properties:
   kind:
     $ref: "#/$defs/Kind"
+  contains:
+    not:
+      description: "Elementary types **must not** specify a `contains` field
+        (to make it easier to discriminate elementary vs. complex)"
 required:
   - kind
 

--- a/schemas/type/elementary/contract.schema.yaml
+++ b/schemas/type/elementary/contract.schema.yaml
@@ -14,6 +14,10 @@ properties:
     type: boolean
     description: If this field is omitted, this type represents an address whose
       payability is not known.
+  library:
+    type: boolean
+  interface:
+    type: boolean
   definition:
     $ref: "schema:ethdebug/format/type/definition"
 


### PR DESCRIPTION
This PR closes six validation gaps found in the schema sweep. Each is a case where an invalid instance validated, or a legitimate one could not be expressed. All existing schema examples still validate, and I verified each fix against its offending instance.

- **type/elementary — forbid `contains`.** The canonical elementary schemas never forbade a `contains` field, so `{ kind: bool, contains: { type: { id: 1 } } }` validated as an elementary type — while the very same object is a *complex* type under `type/base`. That breaks the elementary-vs-complex discriminator the format relies on. Elementary types now reject `contains`, matching `type/base`.
- **type/complex/function — require `kind` and `contains`.** `function` was the only one of the six complex-type schemas without a top-level `required: [kind, contains]`, so `{ external: true }` alone validated as a function and `{ kind: function, internal: true }` (no `contains`) validated through the whole canonical type chain. Now required.
- **type/complex/function — allow `parameters` / `contract` by reference.** The `Parameters` wrapper (and the external `contract` wrapper) pinned `type` to a concrete type, so neither could be given as an `{ id }` reference — even though `returns` in the same file already permits one and the wrapper/specifier machinery exists precisely to allow it. Both now accept a type reference.
- **type/elementary/contract — type the flags.** `library` and `interface` were constrained only inside the `oneOf` consts, so a nonsense value on the non-discriminating flag slipped through: `{ kind: contract, library: true, interface: 42 }` validated. Both are now `type: boolean` at the top level.
- **program/context/name — non-empty name.** `name` is meant to identify a context, but it was a bare `type: string`, so `name: ""` validated. It now carries `minLength: 1`, matching the identifier-like strings elsewhere in the context family.
- **pointer/region — require `location`.** The location dispatcher's seven `if` clauses omitted `required: [location]`, so an object with no `location` vacuously satisfied all seven and was rejected only by accident — with validator errors implicating every region type at once. `location` is now required at the top level (the change that actually rejects a location-less region), and each `if` guards on it so a missing location produces one clear error instead of seven.

Schema example and validity tests pass.