### PR TITLE
format: close objects whose properties the format fully defines

### DIFF
--- a/schemas/info.schema.yaml
+++ b/schemas/info.schema.yaml
@@ -23,6 +23,8 @@ required:
   - compilation
   - programs
 
+unevaluatedProperties: false
+
 examples:
   - compilation:
       id: __301f3b6d85831638

--- a/schemas/materials/compilation.schema.yaml
+++ b/schemas/materials/compilation.schema.yaml
@@ -38,6 +38,8 @@ properties:
       - name
       - version
 
+    unevaluatedProperties: false
+
     examples:
       - name: lllc
         version: 0.4.12-develop.2017.6.27+commit.b83f77e0.Linux.g++
@@ -74,6 +76,8 @@ required:
   - id
   - compiler
   - sources
+
+unevaluatedProperties: false
 
 examples:
   - id: foo

--- a/schemas/materials/source.schema.yaml
+++ b/schemas/materials/source.schema.yaml
@@ -76,6 +76,8 @@ required:
   - contents
   - language
 
+unevaluatedProperties: false
+
 examples:
   - id: 5
     path: ./contracts/SimpleStorage.sol

--- a/schemas/pointer/collection/list.schema.yaml
+++ b/schemas/pointer/collection/list.schema.yaml
@@ -26,6 +26,7 @@ properties:
       - count
       - each
       - is
+    additionalProperties: false
 
 required:
   - list

--- a/schemas/program.schema.yaml
+++ b/schemas/program.schema.yaml
@@ -57,6 +57,8 @@ required:
   - environment
   - instructions
 
+unevaluatedProperties: false
+
 examples:
   - # Incrementing a storage counter
     #

--- a/schemas/program/context/function/return.schema.yaml
+++ b/schemas/program/context/function/return.schema.yaml
@@ -36,6 +36,7 @@ properties:
             $ref: "schema:ethdebug/format/pointer"
         required:
           - pointer
+        additionalProperties: false
 
       success:
         type: object
@@ -48,6 +49,7 @@ properties:
             $ref: "schema:ethdebug/format/pointer"
         required:
           - pointer
+        additionalProperties: false
 
       activation:
         type: string

--- a/schemas/program/context/function/revert.schema.yaml
+++ b/schemas/program/context/function/revert.schema.yaml
@@ -27,6 +27,7 @@ properties:
             $ref: "schema:ethdebug/format/pointer"
         required:
           - pointer
+        additionalProperties: false
 
       panic:
         type: integer

--- a/schemas/program/instruction.schema.yaml
+++ b/schemas/program/instruction.schema.yaml
@@ -57,6 +57,8 @@ properties:
 required:
   - offset
 
+unevaluatedProperties: false
+
 examples:
   - offset: 0
     operation:


### PR DESCRIPTION
The sweep found the format inconsistent about open vs. closed objects: several objects reject unknown keys while their structural siblings accept them silently, so a misspelled key validates in one place and fails in another. This applies one policy — an object whose property set the format fully defines is closed; an object meant to carry compiler- or tool-native extension data stays open — to the objects that finding flagged.

**Closed:**

- **materials/compilation** (and its nested `compiler` object) and **materials/source**, matching the already-closed `materials/reference` and `materials/source-range`. The compiler-native `settings` object stays **open** by design — it holds settings in a format native to the compiler.
- **program**, **program/instruction**, and **info**, matching their closed context and materials siblings. `info` uses `unevaluatedProperties` so the `types` and `pointers` it composes from `info/resources` by `$ref` remain valid, while a misspelled top-level key is rejected.
- The **return.data**, **return.success**, and **revert.reason** pointer wrappers, matching the identically shaped `invoke` wrappers (`target`, `arguments`, `gas`, ...), which were already closed.
- The inner **list** object of `pointer/collection/list` (`count`/`each`/`is`), matching the sibling collection schemas.

**Left open deliberately — `info/resources`.** Because `info` composes it by `$ref`, any closure on `info/resources` is evaluated against the whole `info` document and would reject `info`'s own `programs` key (I confirmed this: it breaks the `info` example). Closing `info` instead achieves the goal for real documents — `info`'s `unevaluatedProperties: false` rejects a misspelled top-level key while still admitting the `types`/`pointers` contributed through the `$ref`. A bare `info/resources` object validated on its own therefore stays lax; flagging in case you'd rather restructure the composition to close it directly.

Schema example and validity tests pass. I also verified out of band that each newly closed object rejects an added misspelled key and that `settings` still accepts arbitrary nested content.