### PR TITLE
format: state the postcondition convention for instruction contexts

### DIFF
--- a/schemas/program.schema.yaml
+++ b/schemas/program.schema.yaml
@@ -36,8 +36,11 @@ properties:
 
   context:
     description: |
-      The context known to exist prior to the execution of the first
-      instruction in the bytecode.
+      The context that holds prior to the execution of the first
+      instruction in the bytecode. This is the base case of the context
+      chain — the precondition to the first instruction — from which each
+      instruction's own `context` follows as a postcondition (see
+      **ethdebug/format/program/instruction**).
 
       This field is **optional**. Omitting it is equivalent to specifying the
       empty context value (`{}`).
@@ -71,7 +74,6 @@ examples:
     # code {
     #   let localValue = storedValue;
     #   storedValue += 1;
-    #   value = tmp;
     # };
     # ```
     contract:
@@ -126,20 +128,17 @@ examples:
       - offset: 4
         operation:
           mnemonic: ADD
+        # ADD consumes localValue, leaving storedValue + 1 on the stack,
+        # so localValue is no longer observable from this point on.
         context:
           variables:
             - *stored-value
-            - *local-value
       - offset: 5
         operation:
           mnemonic: PUSH0
         context:
           variables:
             - *stored-value
-            - <<: *local-value
-              pointer:
-                location: stack
-                slot: 1
 
       - offset: 6
         operation:

--- a/schemas/program/instruction.schema.yaml
+++ b/schemas/program/instruction.schema.yaml
@@ -54,7 +54,11 @@ properties:
       instruction, which is in turn the precondition of the next. A debugger
       paused at the trace step about to execute instruction *i* therefore
       reads the context of instruction *i − 1* — or, before the first
-      instruction, the program-level `context`.
+      instruction, the program-level `context`. Equivalently, prepending
+      the program-level `context` to the sequence of instruction contexts
+      yields a single sequence indexed by trace position, with no special
+      case: the context in effect when about to execute the instruction at
+      position *i* is element *i* of that sequence.
 
       This field is **optional**. Omitting it is equivalent to specifying the
       empty context value (`{}`).

--- a/schemas/program/instruction.schema.yaml
+++ b/schemas/program/instruction.schema.yaml
@@ -42,12 +42,19 @@ properties:
 
   context:
     description: |
-      The context known to exist following the execution of this instruction.
-      "Following execution" means the context's semantic facts (source
-      location, variables in scope, function invocation, etc.) hold from
-      this point forward. Pointers within the context reference the machine
-      state at this instruction's trace step, which is the state a debugger
-      observes when it encounters the instruction.
+      The context that holds **following** the execution of this
+      instruction. Both its semantic facts (source location, variables in
+      scope, function invocation, etc.) and any pointers it contains resolve
+      against the machine state **after** the instruction has executed
+      (its postcondition).
+
+      Instruction contexts form a chain. The program-level `context` is the
+      base case: the precondition that holds before the first instruction
+      executes. Each instruction's context is then the postcondition of that
+      instruction, which is in turn the precondition of the next. A debugger
+      paused at the trace step about to execute instruction *i* therefore
+      reads the context of instruction *i − 1* — or, before the first
+      instruction, the program-level `context`.
 
       This field is **optional**. Omitting it is equivalent to specifying the
       empty context value (`{}`).


### PR DESCRIPTION
Instruction contexts use **postcondition** semantics, pointers included. The description of `program/instruction`'s `context` carried a single sentence framing pointers as resolving against the pre-execution "trace step" state — an outlier that contradicted the rest of that same description ("the context known to exist following the execution"), the `program`-example walkthrough on the spec site, and existing compiler emission. This PR states the convention plainly and fixes the one example that was wrong under it.

- **program/instruction** — a context holds *following* the instruction's execution; both its semantic facts and its pointers resolve against the **post-execution** state. Contexts form a chain: the program-level `context` is the precondition before the first instruction, each instruction's context is its postcondition (and the next instruction's precondition), and a debugger paused about to execute instruction *i* reads instruction *i − 1*'s context.
- **program** — the program-level `context` description now names its role as the base case of that chain (the precondition to the first instruction).
- **program example** — under the postcondition convention the `Incrementer` example was already correct except at the `ADD` and the `PUSH0` after it, which wrongly kept `localValue` listed on the stack; this PR removes it from those two contexts, and nothing else in the example changes. In this example `localValue` is the loaded `storedValue` (`let localValue = storedValue; storedValue += 1;`), so `ADD` consumes it, leaving `storedValue + 1`. Post-execution stack per instruction:

  | offset | op | post-exec stack (top → bottom) | localValue |
  |-------:|------|-------------------------------|------------|
  | 0 | `PUSH0` | `[0x00]` | not yet loaded |
  | 1 | `SLOAD` | `[localValue]` | **slot 0** |
  | 2 | `PUSH1 0x01` | `[localValue, 0x01]` | **slot 1** |
  | 4 | `ADD` | `[storedValue+1]` | consumed |
  | 5 | `PUSH0` | `[storedValue+1, 0x00]` | consumed |
  | 6 | `SSTORE` | `[]` | gone |

  `localValue` is now dropped from the `ADD` and following `PUSH0` contexts, matching how the spec-site walkthrough omits a local once it is consumed. The offset-1 and offset-2 stack pointers were already correct post-execution and are unchanged. A stale `value = tmp;` line is also removed from the pseudo-code.

This supersedes #278, which had reworked the same example toward the pre-execution reading.
