### PR TITLE
format: identify character encodings with WHATWG Encoding Standard labels

### DIFF
--- a/schemas/materials/encoding.schema.yaml
+++ b/schemas/materials/encoding.schema.yaml
@@ -1,0 +1,25 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema:ethdebug/format/materials/encoding"
+
+title: ethdebug/format/materials/encoding
+description: |
+  A character encoding, identified by a label from the WHATWG Encoding
+  Standard (https://encoding.spec.whatwg.org/).
+
+  The value **must** be a label that the Standard defines — for example
+  `utf-8`, `utf-16le`, or `windows-1252`. Where the Standard lists several
+  labels for the same encoding, its canonical (lowercase) name is
+  preferred (`utf-16le` rather than `utf-16`, which the Standard treats as
+  a label for the same encoding). Because these are exactly the labels the
+  `TextDecoder` API accepts, a JavaScript consumer can pass the value
+  straight to `new TextDecoder(label)`.
+
+  Where a field of this type is optional and omitted, the encoding is
+  `utf-8`.
+
+type: string
+
+examples:
+  - utf-8
+  - utf-16le
+  - windows-1252

--- a/schemas/materials/source.schema.yaml
+++ b/schemas/materials/source.schema.yaml
@@ -54,15 +54,15 @@ properties:
 
   encoding:
     description: |
-      Character encoding of original source `contents`. This property
-      is **required** if this encoding does not match the JSON transmission
+      Character encoding of the original source `contents`. This property
+      is **required** if that encoding does not match the JSON transmission
       encoding (UTF-8), since the value of the `contents` property will
-      represent the text of the source of this JSON encoding.
+      represent the text of the source in this JSON encoding.
 
       This property **must not** appear in objects that do not specify
       a `contents` property.
 
-    type: string
+    $ref: "schema:ethdebug/format/materials/encoding"
 
   language:
     description: |

--- a/schemas/type/elementary/string.schema.yaml
+++ b/schemas/type/elementary/string.schema.yaml
@@ -11,11 +11,13 @@ properties:
   kind:
     const: string
   encoding:
-    type: string
+    description: |
+      The character encoding of the string's bytes at runtime.
+    $ref: "schema:ethdebug/format/materials/encoding"
     default: utf-8
 required:
   - kind
 examples:
   - kind: string
   - kind: string
-    encoding: utf-16
+    encoding: utf-16le


### PR DESCRIPTION
Character encodings were free-form strings with no shared vocabulary, so `utf-8` / `UTF-8` / `utf8` were all equally "valid" and a bare `utf-16` did not even pin endianness. This introduces one shared `materials/encoding` primitive and points both encoding sites at it.

`materials/encoding` requires the value to be a label from the [WHATWG Encoding Standard](https://encoding.spec.whatwg.org/), prefers the Standard's canonical lowercase name where an encoding has several labels, and defaults to `utf-8` on omission. These are exactly the labels the `TextDecoder` API accepts, so a JavaScript consumer passes the value straight through to `new TextDecoder(label)`.

Both sites now `$ref` it:
- `type/elementary/string.encoding` — the encoding of a string value's bytes at runtime;
- `materials/source.encoding` — the encoding of the original source text.

The `string` example's `utf-16` becomes the canonical `utf-16le`, which also fixes the endianness a bare `utf-16` leaves unspecified.

This also lands the shared encoding primitive that the language-agnostic types discussion (#282) will want, since character encoding is one of the encoding properties raised there.

Schema example and validity tests pass.